### PR TITLE
Turn the warning modal style into a flag

### DIFF
--- a/src/actions/LoginInitActions.tsx
+++ b/src/actions/LoginInitActions.tsx
@@ -188,8 +188,7 @@ const checkAndRequestNotifications = (
         bridge={bridge}
         title={s.strings.alert_modal_title}
         message={message}
-        borderColor={theme.warningText}
-        borderWidth={4}
+        warning
         buttons={{
           enable: { label: s.strings.enable },
           cancel: { label: s.strings.cancel, type: 'escape' }

--- a/src/components/modals/ButtonsModal.tsx
+++ b/src/components/modals/ButtonsModal.tsx
@@ -39,8 +39,7 @@ export function ButtonsModal<
   closeArrow?: boolean
   message?: string
   title?: string
-  borderColor?: string
-  borderWidth?: number
+  warning?: boolean
 }) {
   const {
     bridge,
@@ -48,16 +47,16 @@ export function ButtonsModal<
     children,
     closeArrow = false,
     message,
-    title
+    title,
+    warning = false
   } = props
   const handleCancel = () => bridge.resolve(undefined)
 
   return (
     <ThemedModal
       bridge={bridge}
-      borderColor={props.borderColor}
-      borderWidth={props.borderWidth}
       paddingRem={1}
+      warning={warning}
       onCancel={handleCancel}
     >
       {title != null ? <TitleText>{title}</TitleText> : null}

--- a/src/components/modals/SecurityAlertsModal.tsx
+++ b/src/components/modals/SecurityAlertsModal.tsx
@@ -21,13 +21,12 @@ type Props = OwnProps & ThemeProps
 
 class SecurityAlertsModalComponent extends React.Component<Props> {
   render() {
-    const { bridge, theme } = this.props
+    const { bridge } = this.props
 
     return (
       <ThemedModal
-        borderColor={theme.warningText}
-        borderWidth={4}
         bridge={bridge}
+        warning
         onCancel={() => bridge.resolve(undefined)}
       >
         <TitleText>{s.strings.alert_modal_title}</TitleText>

--- a/src/components/themed/ThemedModal.tsx
+++ b/src/components/themed/ThemedModal.tsx
@@ -8,16 +8,24 @@ import { useTheme } from '../services/ThemeContext'
 interface Props<T> {
   bridge: AirshipBridge<T>
   children?: React.ReactNode
-  onCancel: () => void
 
   // Control over the content area:
   paddingRem?: number[] | number
-  borderColor?: string
-  borderWidth?: number
+
+  // Adds a yellow warning border:
+  warning?: boolean
+
+  onCancel: () => void
 }
 
 export function ThemedModal<T>(props: Props<T>) {
-  const { bridge, children = null, onCancel, paddingRem } = props
+  const {
+    bridge,
+    children = null,
+    warning = false,
+    paddingRem,
+    onCancel
+  } = props
   const theme = useTheme()
 
   // Since we can't add native dependencies without a major version bump,
@@ -34,8 +42,9 @@ export function ThemedModal<T>(props: Props<T>) {
       'rgba(0, 0, 0, 0.75)'
     )
 
-  const borderColor = props.borderColor ?? theme.modalBorderColor
-  const borderWidth = props.borderWidth ?? theme.modalBorderWidth
+  // TODO: The warning styles are incorrectly hard-coded:
+  const borderColor = warning ? theme.warningText : theme.modalBorderColor
+  const borderWidth = warning ? 4 : theme.modalBorderWidth
 
   return (
     <AirshipModal


### PR DESCRIPTION
We should not be passing around raw styles. If components have different appearances, those should be named based on their purpose.