### PR TITLE
Add skip button for changePasswordScene

### DIFF
--- a/src/common/locales/strings/de.json
+++ b/src/common/locales/strings/de.json
@@ -34,6 +34,8 @@
   "cancel": "Abbrechen",
   "enable": "Aktivieren",
   "continue": "Weiter",
+  "change_password": "Passwort ändern",
+  "change_pin": "PIN ändern",
   "pin_changed": "PIN wurde erfolgreich geändert",
   "delete_account": "Benutzerkonto löschen?",
   "pin_successfully_changed": "PIN erfolgreich geändert",

--- a/src/common/locales/strings/enUS.json
+++ b/src/common/locales/strings/enUS.json
@@ -34,6 +34,8 @@
   "cancel": "Cancel",
   "enable": "Enable",
   "continue": "Continue",
+  "change_password": "Change Password",
+  "change_pin": "Change PIN",
   "pin_changed": "PIN Changed",
   "delete_account": "Delete Account?",
   "pin_successfully_changed": "PIN Successfully Changed",

--- a/src/common/locales/strings/es.json
+++ b/src/common/locales/strings/es.json
@@ -34,6 +34,8 @@
   "cancel": "Cancelar",
   "enable": "Habilitar",
   "continue": "Continuar",
+  "change_password": "Cambiar contraseña",
+  "change_pin": "Cambiar NIP",
   "pin_changed": "NIP cambiado",
   "delete_account": "¿Borrar cuenta?",
   "pin_successfully_changed": "PIN cambiado con éxito",

--- a/src/common/locales/strings/fr.json
+++ b/src/common/locales/strings/fr.json
@@ -34,6 +34,8 @@
   "cancel": "Annuler",
   "enable": "Activer",
   "continue": "Continue",
+  "change_password": "Changer le mot de passe",
+  "change_pin": "Modifier le code PIN",
   "pin_changed": "Code PIN modifié",
   "delete_account": "Supprimer ce compte?",
   "pin_successfully_changed": "Le code PIN a bien été modifié",

--- a/src/common/locales/strings/it.json
+++ b/src/common/locales/strings/it.json
@@ -34,6 +34,8 @@
   "cancel": "Annulla",
   "enable": "Abilita",
   "continue": "Continua",
+  "change_password": "Cambia password",
+  "change_pin": "Cambia PIN",
   "pin_changed": "PIN modificato",
   "delete_account": "Rimuovere l'account?",
   "pin_successfully_changed": "PIN modificato con successo",

--- a/src/common/locales/strings/ja.json
+++ b/src/common/locales/strings/ja.json
@@ -34,6 +34,8 @@
   "cancel": "キャンセル",
   "enable": "有効にする",
   "continue": "Continue",
+  "change_password": "パスワードを変更",
+  "change_pin": "PINを変更",
   "pin_changed": "PINが変更されました",
   "delete_account": "アカウントを削除しますか？",
   "pin_successfully_changed": "PINが正常に変更されました",

--- a/src/common/locales/strings/ko.json
+++ b/src/common/locales/strings/ko.json
@@ -34,6 +34,8 @@
   "cancel": "취소",
   "enable": "활성화",
   "continue": "Continue",
+  "change_password": "암호 변경",
+  "change_pin": "PIN 변경",
   "pin_changed": "PIN 변경됨",
   "delete_account": "계정을 삭제하시겠습니까?",
   "pin_successfully_changed": "PIN이 성공적으로 변경되었습니다.",

--- a/src/common/locales/strings/pt.json
+++ b/src/common/locales/strings/pt.json
@@ -34,6 +34,8 @@
   "cancel": "Cancelar",
   "enable": "Ativar",
   "continue": "Continue",
+  "change_password": "Alterar Senha",
+  "change_pin": "Alterar PIN",
   "pin_changed": "PIN Alterado",
   "delete_account": "Excluir Conta?",
   "pin_successfully_changed": "PIN alterado com sucesso",

--- a/src/common/locales/strings/ru.json
+++ b/src/common/locales/strings/ru.json
@@ -34,6 +34,8 @@
   "cancel": "Отмена",
   "enable": "Включить",
   "continue": "Continue",
+  "change_password": "Сменить пароль",
+  "change_pin": "Сменить PIN",
   "pin_changed": "PIN изменен",
   "delete_account": "Удалить учетную запись?",
   "pin_successfully_changed": "PIN-код успешно изменен",

--- a/src/common/locales/strings/vi.json
+++ b/src/common/locales/strings/vi.json
@@ -34,6 +34,8 @@
   "cancel": "Huỷ",
   "enable": "Kích hoạt",
   "continue": "Continue",
+  "change_password": "Thay đổi mật khẩu",
+  "change_pin": "Thay đổi mã PIN",
   "pin_changed": "Mã PIN đã được đổi",
   "delete_account": "Xoá tài khoản?",
   "pin_successfully_changed": "Thay đổi mật khẩu thành công",

--- a/src/common/locales/strings/zh.json
+++ b/src/common/locales/strings/zh.json
@@ -34,6 +34,8 @@
   "cancel": "取消",
   "enable": "启用",
   "continue": "Continue",
+  "change_password": "更改密码",
+  "change_pin": "更改PIN码",
   "pin_changed": "PIN码已改变",
   "delete_account": "删除帐户?",
   "pin_successfully_changed": "PIN码修改成功",

--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -234,7 +234,11 @@ export const ResecurePasswordScene = () => {
   })
 
   return (
-    <ChangePasswordSceneComponent onSkip={handleSkip} onSubmit={handleSubmit} />
+    <ChangePasswordSceneComponent
+      onSkip={handleSkip}
+      title={s.strings.change_password}
+      onSubmit={handleSubmit}
+    />
   )
 }
 

--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -25,6 +25,7 @@ import { ThemedScene } from '../themed/ThemedScene'
 interface Props {
   title?: string | undefined
   onBack?: (() => void) | undefined
+  onSkip?: (() => void) | undefined
   onSubmit: (password: string) => void
   mainButtonLabel?: string
 }
@@ -32,6 +33,7 @@ interface Props {
 const ChangePasswordSceneComponent = ({
   title,
   onBack,
+  onSkip,
   onSubmit,
   mainButtonLabel = s.strings.done
 }: Props) => {
@@ -141,7 +143,7 @@ const ChangePasswordSceneComponent = ({
   }
 
   return (
-    <ThemedScene onBack={onBack} title={title}>
+    <ThemedScene onBack={onBack} onSkip={onSkip} title={title}>
       {focusSecond ? (
         <KeyboardAvoidingView
           style={styles.container}
@@ -176,7 +178,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
   }
 }))
 
-const CommonChangePasswordScene = (action: any) => {
+// The scene for existing users to change their password
+export const ChangePasswordScene = () => {
   const dispatch = useDispatch()
   const account = useSelector(state => state.account ?? undefined)
 
@@ -193,7 +196,7 @@ const CommonChangePasswordScene = (action: any) => {
           buttons={{ ok: { label: s.strings.ok } }}
         />
       ))
-      dispatch(action())
+      dispatch(onComplete())
     } catch (e) {
       showError(e)
     }
@@ -202,12 +205,38 @@ const CommonChangePasswordScene = (action: any) => {
   return <ChangePasswordSceneComponent onSubmit={handleSubmit} />
 }
 
-// The scene for existing users to change their password
-export const ChangePasswordScene = () => CommonChangePasswordScene(onComplete)
-
 // The scene for existing users to recover their password
-export const ResecurePasswordScene = () =>
-  CommonChangePasswordScene(() => ({ type: 'RESECURE_PIN' }))
+export const ResecurePasswordScene = () => {
+  const dispatch = useDispatch()
+  const account = useSelector(state => state.account ?? undefined)
+
+  const handleSkip = useHandler(() => {
+    dispatch({ type: 'RESECURE_PIN' })
+  })
+
+  const handleSubmit = useHandler(async (password: string) => {
+    Keyboard.dismiss()
+    if (account == null) return
+    try {
+      await account.changePassword(password)
+      await Airship.show(bridge => (
+        <ButtonsModal
+          bridge={bridge}
+          title={s.strings.password_changed}
+          message={s.strings.pwd_change_modal}
+          buttons={{ ok: { label: s.strings.ok } }}
+        />
+      ))
+      dispatch({ type: 'RESECURE_PIN' })
+    } catch (e) {
+      showError(e)
+    }
+  })
+
+  return (
+    <ChangePasswordSceneComponent onSkip={handleSkip} onSubmit={handleSubmit} />
+  )
+}
 
 // The scene for new users to create a password
 export const NewAccountPasswordScene = () => {

--- a/src/components/scenes/ChangePinScene.tsx
+++ b/src/components/scenes/ChangePinScene.tsx
@@ -137,7 +137,13 @@ export const ResecurePinScene = () => {
       showError(e)
     }
   })
-  return <ChangePinSceneComponent onSkip={handleSkip} onSubmit={handleSubmit} />
+  return (
+    <ChangePinSceneComponent
+      onSkip={handleSkip}
+      title={s.strings.change_pin}
+      onSubmit={handleSubmit}
+    />
+  )
 }
 
 // The scene for new users to set their PIN

--- a/src/components/scenes/ChangePinScene.tsx
+++ b/src/components/scenes/ChangePinScene.tsx
@@ -20,6 +20,7 @@ import { ThemedScene } from '../themed/ThemedScene'
 interface Props {
   title?: string
   onBack?: () => void
+  onSkip?: (() => void) | undefined
   onSubmit: (pin: string) => void
   mainButtonLabel?: string
 }
@@ -27,6 +28,7 @@ interface Props {
 const ChangePinSceneComponent = ({
   title,
   onBack,
+  onSkip,
   onSubmit,
   mainButtonLabel = s.strings.done
 }: Props) => {
@@ -43,7 +45,7 @@ const ChangePinSceneComponent = ({
   const scrollViewRef = useScrollToEnd(isValidPin)
 
   return (
-    <ThemedScene onBack={onBack} title={title}>
+    <ThemedScene onBack={onBack} onSkip={onSkip} title={title}>
       <ScrollView ref={scrollViewRef} style={styles.content}>
         <EdgeText style={styles.description} numberOfLines={2}>
           {s.strings.pin_desc}
@@ -82,7 +84,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
   }
 }))
 
-const CommonChangePinScene = (action: any) => {
+// The scene for existing users to change their PIN
+export const ChangePinScene = () => {
   const dispatch = useDispatch()
   const account = useSelector(state => state.account ?? undefined)
 
@@ -99,20 +102,43 @@ const CommonChangePinScene = (action: any) => {
           buttons={{ ok: { label: s.strings.ok } }}
         />
       ))
-      dispatch(action())
+      dispatch(onComplete())
     } catch (e) {
       showError(e)
     }
   })
-
   return <ChangePinSceneComponent onSubmit={handleSubmit} />
 }
 
-// The scene for existing users to change their PIN
-export const ChangePinScene = () => CommonChangePinScene(onComplete)
-
 // The scene for new users to recover their PIN
-export const ResecurePinScene = () => CommonChangePinScene(completeResecure)
+export const ResecurePinScene = () => {
+  const dispatch = useDispatch()
+  const account = useSelector(state => state.account ?? undefined)
+
+  const handleSkip = () => {
+    dispatch(completeResecure())
+  }
+
+  const handleSubmit = useHandler(async (pin: string) => {
+    Keyboard.dismiss()
+    if (account == null) return
+    try {
+      await account.changePin({ pin })
+      await Airship.show(bridge => (
+        <ButtonsModal
+          bridge={bridge}
+          title={s.strings.pin_changed}
+          message={s.strings.pin_successfully_changed}
+          buttons={{ ok: { label: s.strings.ok } }}
+        />
+      ))
+      dispatch(completeResecure())
+    } catch (e) {
+      showError(e)
+    }
+  })
+  return <ChangePinSceneComponent onSkip={handleSkip} onSubmit={handleSubmit} />
+}
 
 // The scene for new users to set their PIN
 export const NewAccountPinScene = () => {


### PR DESCRIPTION
Note that the the skip button is also missing from the 
changePinScene. 

Other elements we might want to add include header
titles. 

![Simulator Screen Shot - iPhone 13 - 2022-07-07 at 13 10 23](https://user-images.githubusercontent.com/23110002/177863411-ca744111-2347-469c-9aa2-ffd5d2142b4c.png)
![Simulator Screen Shot - iPhone 13 - 2022-07-07 at 13 10 39](https://user-images.githubusercontent.com/23110002/177863418-3f2b3e04-7540-45d6-9c2f-f211bae50ba3.png)
![Simulator Screen Shot - iPhone 13 - 2022-07-07 at 13 10 46](https://user-images.githubusercontent.com/23110002/177863419-36b66812-107d-4396-bef4-2cfbe4229519.png)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202557121364018