### PR TITLE
Fix the double modal popup

### DIFF
--- a/src/hooks/useClearOnUnmount.ts
+++ b/src/hooks/useClearOnUnmount.ts
@@ -6,5 +6,9 @@ import { Airship } from '../components/services/AirshipInstance'
  * Clears modals when the component unmounts.
  */
 export function useClearOnUnmount() {
-  React.useEffect(() => Airship.clear, [])
+  React.useEffect(() => {
+    return () => {
+      Airship.clear()
+    }
+  }, [])
 }


### PR DESCRIPTION
Itay identified that the `useClearOnUnmount` hook was somehow causing the double modal popup, but wasn't sure why. I edited the hook to add debugging, but the problem disappeared. So, here is the fix that makes no sense.