### PR TITLE
Add a spinner to `ChangePasswordSceneComponent` to prevent double submit

### DIFF
--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -44,6 +44,7 @@ const ChangePasswordSceneComponent = ({
   const [focusFirst, setFocusFirst] = React.useState(true)
   const [focusSecond, setFocusSecond] = React.useState(false)
   const [hidePassword, setHidePassword] = React.useState(true)
+  const [spinning, setSpinning] = React.useState(false)
 
   const hasPasswordStatus = useSelector(state => state.passwordStatus != null)
   const passed = useSelector(state => state?.passwordStatus?.passed ?? false)
@@ -57,7 +58,6 @@ const ChangePasswordSceneComponent = ({
   const createError = useSelector(
     state => state.create.createPasswordErrorMessage ?? ''
   )
-
   const hasError = confirmError !== '' || createError !== ''
   const isValidPassword = passed && password === confirmPassword && !hasError
 
@@ -73,7 +73,15 @@ const ChangePasswordSceneComponent = ({
       return
     }
 
-    return onSubmit(password)
+    setSpinning(true)
+
+    try {
+      onSubmit(password)
+    } catch (e) {
+      showError(e)
+    } finally {
+      setSpinning(false)
+    }
   })
 
   const handleFocusSwitch = () => {
@@ -133,11 +141,23 @@ const ChangePasswordSceneComponent = ({
         </FormError>
         <View style={styles.actions}>
           <Fade visible={isValidPassword} hidden>
-            <MainButton
-              label={mainButtonLabel}
-              type="secondary"
-              onPress={handlePress}
-            />
+            {spinning ? (
+              <MainButton
+                alignSelf="center"
+                disabled
+                marginRem={0.5}
+                type="secondary"
+                spinner
+              />
+            ) : (
+              <MainButton
+                alignSelf="center"
+                label={mainButtonLabel}
+                marginRem={0.5}
+                onPress={handlePress}
+                type="secondary"
+              />
+            )}
           </Fade>
         </View>
       </>
@@ -184,7 +204,6 @@ const getStyles = cacheStyles((theme: Theme) => ({
 export const ChangePasswordScene = () => {
   const dispatch = useDispatch()
   const account = useSelector(state => state.account ?? undefined)
-
   const handleSubmit = useHandler(async (password: string) => {
     Keyboard.dismiss()
     if (account == null) return


### PR DESCRIPTION
Double modal issue caused by pressing "enter" on keyboard, sending a change password request, followed by pressing "Done" which fires the second change password request. This PR prevents double submission from being possible by adding a spinner to the "Done" button.

| Airplane mode                                                                                                                                      | Pressing enter key                                                                                                                        |
|----------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
| <video controls width="200" src="https://user-images.githubusercontent.com/4023066/186565718-5c3cf5ec-4c8a-46f4-aa15-350eb89deea9.mp4" /> autoplay | <video controls width="200" src="https://user-images.githubusercontent.com/4023066/186565711-6258264c-fc55-4a02-b082-83a343434db7.mp4" /> |


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202719701993762