### PR TITLE
Fix >4 digit pin length + only call `loginWithPin()` when 4th digit entered

### DIFF
--- a/src/components/scenes/PinLoginScene.tsx
+++ b/src/components/scenes/PinLoginScene.tsx
@@ -114,9 +114,12 @@ class PinLoginSceneComponent extends React.Component<Props, State> {
 
   handlePress = (value: string) => {
     const { loginWithPin, onChangeText, pin, username } = this.props
-    const newPin = value === 'back' ? pin.slice(0, -1) : pin.concat(value)
+    const newPin =
+      value === 'back' ? pin.slice(0, -1) : pin.concat(value).slice(0, 4)
+    if (newPin.length === 4 && pin.length === 3) {
+      loginWithPin(username, newPin)
+    }
     onChangeText(newPin)
-    if (newPin.length === 4) loginWithPin(username, newPin)
   }
 
   render() {


### PR DESCRIPTION
Prevents multiple logins by only logging in when the pin length changes from 3 to 4. 
This PR additionally fixes the double/triple "Remember your password?" modal popup resulting from multiple logins initiated.

https://user-images.githubusercontent.com/4023066/186586787-107eab96-ee84-41da-92d8-9ffacc646328.mp4


