### PR TITLE
Fix bug which allows a user to bypass password requirements

### DIFF
--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -65,6 +65,7 @@ const ChangePasswordSceneComponent = ({
   })
 
   const handlePress = useHandler(async () => {
+    if (!isRequirementsMet) return
     if (password !== confirmPassword) {
       setIsShowError(true)
       return


### PR DESCRIPTION
If the user uses the return key on their device's keyboard, they're able to bypass the password requirements with an empty password.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203570354063840