### PR TITLE
Add flexGrow to username dropdown

### DIFF
--- a/src/components/scenes/PasswordLoginScene.tsx
+++ b/src/components/scenes/PasswordLoginScene.tsx
@@ -402,6 +402,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
     flexDirection: 'row'
   },
   dropDownList: {
+    flexGrow: 0,
     maxHeight: theme.rem(12.5),
     backgroundColor: theme.backgroundGradientColors[0]
   },


### PR DESCRIPTION
Makes list height no more than needed to show the number of usernames

<img width="519" alt="Screen Shot 2022-12-20 at 10 52 13" src="https://user-images.githubusercontent.com/6079354/208744162-600fb7a1-f01d-4f77-9919-3dac37f165ef.png">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203582776512851