### PR TITLE
Move all native dependencies into devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ First, add the Edge libraries to your project:
 
 The login UI depends on some extra external native libraries, which you will have to install as well:
 
-- disklet
+- @react-native-community/datetimepicker v6
+- disklet v0.5
+- react-native-gesture-handler v2
 - react-native-linear-gradient v2
 - react-native-localize v2
 - react-native-mail v6
@@ -27,7 +29,7 @@ The login UI depends on some extra external native libraries, which you will hav
   - Follow the [extra installation steps](https://www.npmjs.com/package/react-native-vector-icons#installation).
   - We use AntDesign, Entypo, MaterialIcons, FontAwesome, FontAwesome5, and SimpleLineIcons.
 
-To initialize the Edge core library, your application needs to mount the `MakeEdgeContext` component and keep it around for the lifetime of the app. This component will create and manage an `EdgeContext` object.
+To initialize the Edge core library, your application needs to mount the `MakeEdgeContext` component and keep it around for the lifetime of the app. The `MakeEdgeContext` component will create and manage an `EdgeContext` object.
 
 You should also wrap your entire application in a `LoginUiProvider` component, which the login scene needs to display modals, error alerts, and similar floating UI:
 

--- a/package.json
+++ b/package.json
@@ -39,23 +39,13 @@
     "sha3": "2.1.4"
   },
   "dependencies": {
-    "@react-native-community/datetimepicker": "^6.1.2",
     "cleaners": "^0.3.12",
     "date-fns": "^2.23.0",
     "qrcode-generator": "^1.4.4",
     "react-native-airship": "^0.2.9",
-    "react-native-gesture-handler": "^2.5.0",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
-    "react-native-linear-gradient": "^2.0.0",
-    "react-native-localize": "^2.0.2",
-    "react-native-mail": "^6.1.0",
     "react-native-material-textfield": "https://github.com/EdgeApp/react-native-material-textfield.git",
     "react-native-patina": "^0.1.6",
-    "react-native-permissions": "^3.0.1",
-    "react-native-reanimated": "^2.0.0",
-    "react-native-share": "^5.1.4",
-    "react-native-svg": "^12.1.0",
-    "react-native-vector-icons": "^7.1.0",
     "react-redux": "^7.2.4",
     "redux": "~3.5.2",
     "redux-thunk": "~2.1.0",
@@ -63,6 +53,7 @@
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
+    "@react-native-community/datetimepicker": "^6.1.2",
     "@types/react-native": "^0.64.4",
     "@types/react-native-share": "^3.3.3",
     "@types/react-native-vector-icons": "^6.4.8",
@@ -73,6 +64,7 @@
     "@typescript-eslint/parser": "^4.8.2",
     "babel-eslint": "^10.1.0",
     "css-module-flow": "^1.0.0",
+    "disklet": "^0.5.2",
     "edge-core-js": "^0.18.2",
     "eslint": "^7.14.0",
     "eslint-config-standard-kit": "0.15.1",
@@ -89,13 +81,21 @@
     "husky": "^7.0.0",
     "lint-staged": "^10.5.3",
     "prettier": "^2.2.0",
+    "react-native-gesture-handler": "^2.5.0",
+    "react-native-linear-gradient": "^2.0.0",
+    "react-native-localize": "^2.0.2",
+    "react-native-mail": "^6.1.0",
+    "react-native-permissions": "^3.0.1",
+    "react-native-reanimated": "^2.0.0",
+    "react-native-share": "^5.1.4",
+    "react-native-svg": "^12.1.0",
+    "react-native-vector-icons": "^7.1.0",
     "rimraf": "^3.0.2",
     "sucrase": "^3.19.0",
     "typescript": "^4.1.2",
     "yarn-deduplicate": "^5.0.0"
   },
   "peerDependencies": {
-    "@react-native-community/art": "*",
     "react": "*",
     "react-native": "*"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,9 +170,9 @@
     fastq "^1.6.0"
 
 "@react-native-community/datetimepicker@^6.1.2":
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-6.7.1.tgz#a52eed9512898adef323b2fa78c6ac4611af5502"
-  integrity sha512-NPW1YITG7N+3TsqXc4LZV3c5IEpTD5iX18r0bvFsHdIblo5qi0ykpeK3TffmMM5gbTjgKJ4DNVHOjLiWKxFUxw==
+  version "6.7.4"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-6.7.4.tgz#1c29f9305ce5d3841647d2a6823d4efcb2dcad1b"
+  integrity sha512-a6O1cFJslChHdrFAWc6H+2VJehhjY1hDoLKRgO2L31S5S/59WCIgOmknXwEX/MBg4Jh8PKZJ7DeIkbiON253BA==
   dependencies:
     invariant "^2.2.4"
 
@@ -845,6 +845,13 @@ disklet@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/disklet/-/disklet-0.4.5.tgz#f62546a94f939cca4dd20d9c3d5c5e43c9529441"
   integrity sha512-ivPnHcgFOR5kXcAhR2pMrwtNfNAtoWW0SZ0laSFCr4vboU28PERUKLtUeCC0PWh/X3ykZ+3UFE5doALSOuthnQ==
+  dependencies:
+    rfc4648 "^1.3.0"
+
+disklet@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/disklet/-/disklet-0.5.2.tgz#eb1b3bfc2840883cb432aaa16d2c78a345cdd778"
+  integrity sha512-Fx9LFHztHa47QVCHKaABvk+R/zInmi17HweWM+PQyO3bv55E709IPcJIMOH1WyuPNTPHAAM9GToN6NgpdLhUCQ==
   dependencies:
     rfc4648 "^1.3.0"
 


### PR DESCRIPTION
The end-user needs to install these manually for React Native to find and link them. So, we put them in our readme file and our devDependencies.