### PR TITLE
Fix broken 'Confirm and Email' Recovery setup button

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The login UI depends on some extra external native libraries, which you will hav
 
 - @react-native-community/datetimepicker v6
 - disklet v0.5
+- react-native-email-link v1
 - react-native-gesture-handler v2
 - react-native-linear-gradient v2
 - react-native-localize v2

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "lint-staged": "^10.5.3",
     "nodemon": "^2.0.20",
     "prettier": "^2.2.0",
+    "react-native-email-link": "^1.14.5",
     "react-native-gesture-handler": "^2.5.0",
     "react-native-linear-gradient": "^2.0.0",
     "react-native-localize": "^2.0.2",

--- a/src/components/scenes/existingAccout/ChangeRecoveryScene.tsx
+++ b/src/components/scenes/existingAccout/ChangeRecoveryScene.tsx
@@ -165,21 +165,14 @@ export const ChangeRecoveryScene = ({ branding }: Props) => {
     })
   }
   const renderSaveRecoveryMessage = (showEmailPrompt: boolean) => {
-    const paddingRem = [0, 0.5]
     return (
-      <View style={styles.confirmRecoveryMessageContainer}>
-        <ModalMessage paddingRem={paddingRem}>
-          {s.strings.recovery_save_hint_token}
-        </ModalMessage>
-        <ModalMessage isWarning paddingRem={paddingRem}>
-          {s.strings.recovery_save_hint_username_answers}
-        </ModalMessage>
-        {showEmailPrompt ? (
-          <ModalMessage paddingRem={paddingRem}>
-            {s.strings.recovery_save_email_prompt}
-          </ModalMessage>
-        ) : null}
-      </View>
+      <ModalMessage>
+        {s.strings.recovery_save_hint_token + '\n\n'}
+        <Text style={styles.warningText}>
+          {s.strings.recovery_save_hint_username_answers + '\n\n'}
+        </Text>
+        {showEmailPrompt ? s.strings.recovery_save_email_prompt : null}
+      </ModalMessage>
     )
   }
 
@@ -413,11 +406,6 @@ const getStyles = cacheStyles((theme: Theme) => ({
   buttonsContainer: {
     marginHorizontal: theme.rem(1)
   },
-  confirmRecoveryMessageContainer: {
-    alignItems: 'flex-start',
-    display: 'flex',
-    flexDirection: 'column'
-  },
   disableButtonContainer: {
     alignSelf: 'center',
     paddingVertical: theme.rem(1)
@@ -427,5 +415,8 @@ const getStyles = cacheStyles((theme: Theme) => ({
     marginBottom: theme.rem(1),
     fontSize: theme.rem(1),
     fontFamily: theme.fontFaceDefault
+  },
+  warningText: {
+    color: theme.warningText
   }
 }))

--- a/src/components/themed/ModalParts.tsx
+++ b/src/components/themed/ModalParts.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
-import { Text, TouchableOpacity, View } from 'react-native'
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native'
 import { cacheStyles } from 'react-native-patina'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 
 import { fixSides, mapSides, sidesToPadding } from '../../util/sides'
+import { GradientFadeOut } from '../modals/GradientFadeout'
 import { Theme, useTheme } from '../services/ThemeContext'
 
 interface ModalTitleProps {
@@ -11,6 +12,10 @@ interface ModalTitleProps {
   center?: boolean
   paddingRem?: number[] | number
   icon?: React.ReactNode
+}
+interface ModalFooterProps {
+  onPress: () => void
+  fadeOut?: boolean | undefined
 }
 
 export function ModalTitle(props: ModalTitleProps) {
@@ -55,7 +60,7 @@ export function ModalCloseArrow(props: { onPress?: () => void }) {
   const styles = getStyles(theme)
 
   return (
-    <TouchableOpacity onPress={props.onPress} style={styles.closeArrow}>
+    <TouchableOpacity onPress={props.onPress} style={styles.closeIcon}>
       <AntDesignIcon
         name="close"
         size={theme.rem(1.25)}
@@ -65,10 +70,60 @@ export function ModalCloseArrow(props: { onPress?: () => void }) {
   )
 }
 
+export function ModalFooter(props: ModalFooterProps) {
+  const theme = useTheme()
+  const styles = getStyles(theme)
+  const { fadeOut } = props
+
+  const footerFadeContainer =
+    fadeOut === true ? styles.footerFadeContainer : undefined
+  const footerFade = fadeOut === true ? styles.footerFade : undefined
+
+  return (
+    <View style={footerFadeContainer}>
+      <View style={footerFade}>
+        <TouchableOpacity
+          onPress={props.onPress}
+          style={styles.closeIcon}
+          accessibilityHint="Close Modal"
+        >
+          <AntDesignIcon
+            name="close"
+            size={theme.rem(1.25)}
+            color={theme.iconTappable}
+          />
+        </TouchableOpacity>
+      </View>
+      {fadeOut !== true ? null : <GradientFadeOut />}
+    </View>
+  )
+}
+
+export function ModalScrollArea(props: {
+  children: React.ReactNode
+  onCancel: () => void
+}) {
+  const { children, onCancel } = props
+  const theme = useTheme()
+  const styles = getStyles(theme)
+
+  return (
+    <View>
+      <ScrollView contentContainerStyle={styles.scrollPadding}>
+        {children}
+      </ScrollView>
+      <ModalFooter onPress={onCancel} fadeOut />
+    </View>
+  )
+}
+
 const getStyles = cacheStyles((theme: Theme) => ({
-  closeArrow: {
+  closeIcon: {
     alignItems: 'center',
     paddingTop: theme.rem(1)
+  },
+  scrollPadding: {
+    paddingBottom: theme.rem(2.5)
   },
   titleContainer: {
     alignItems: 'center',
@@ -96,5 +151,15 @@ const getStyles = cacheStyles((theme: Theme) => ({
     fontSize: theme.rem(1),
     marginVertical: theme.rem(0.5),
     textAlign: 'left'
+  },
+  footerFadeContainer: {
+    marginBottom: theme.rem(-1)
+  },
+  footerFade: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 1
   }
 }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,6 +2525,11 @@ react-native-airship@^0.2.9:
   dependencies:
     yavent "^0.1.1"
 
+react-native-email-link@^1.14.5:
+  version "1.14.5"
+  resolved "https://registry.yarnpkg.com/react-native-email-link/-/react-native-email-link-1.14.5.tgz#05e13002bd850ebaf98477b4cfbfdfa972a57608"
+  integrity sha512-TNi9OeGcJlw6FXl1dWAKEBGJEgKPBfsiB3v8GaHqqCtzmWnKE+8y1Wfhaaloh37OJb2vqp1cwDpW5m6PiTXazA==
+
 react-native-gesture-handler@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.5.0.tgz#61385583570ed0a45a9ed142425e35f8fe8274fb"


### PR DESCRIPTION
Fix broken 'Confirm and Email' on Android by switching from using [react-native-mail](https://github.com/chirag04/react-native-mail) to [react-native-email-link](https://github.com/includable/react-native-email-link). 

The first commit which copies the `ModalFooter` / `ModalScrollArea` / `accessibilityHint="Close Modal"` from the GUI is optional.

### CHANGELOG

Fix broken 'Confirm and Email' on Android

### Dependencies

https://github.com/EdgeApp/edge-react-gui/pull/4118

### Description

| Enter your email 	| Email app choice 	|
|---	|---	|
| ![email-modal](https://user-images.githubusercontent.com/4023066/231287228-6e0fbeae-6e57-4aa7-b1a6-ead273925c94.jpg) 	| ![email](https://user-images.githubusercontent.com/4023066/231287202-7246a846-a4ff-403d-aa8f-1fc6a58ce61d.jpg) 	|

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204304094867122