### PR TITLE
Re-implement accidentally reverted onComplete changes

### DIFF
--- a/src/actions/LoginInitActions.tsx
+++ b/src/actions/LoginInitActions.tsx
@@ -17,7 +17,6 @@ import {
   RequestPermissionsModal
 } from '../components/modals/RequestPermissionsModal'
 import { SecurityAlertsModal } from '../components/modals/SecurityAlertsModal'
-import { InitialRouteName } from '../components/publicApi/types'
 import { Airship, showError } from '../components/services/AirshipInstance'
 import { scene as sceneReducer } from '../reducers/SceneReducer'
 import { Branding } from '../types/Branding'
@@ -41,10 +40,11 @@ const notificationPermissionsInfoFile = 'notificationsPermisions.json'
 /**
  * Fires off all the things we need to do to get the login scene up & running.
  */
-export const initializeLogin = (
-  branding: Branding,
-  initialRoute?: InitialRouteName
-) => async (dispatch: Dispatch, getState: GetState, imports: Imports) => {
+export const initializeLogin = () => async (
+  dispatch: Dispatch,
+  getState: GetState,
+  imports: Imports
+) => {
   const { customPermissionsFunction } = imports
   const touchPromise = dispatch(loadTouchState())
   dispatch(checkSecurityMessages()).catch(error => console.log(error))

--- a/src/components/publicApi/LoginScreen.tsx
+++ b/src/components/publicApi/LoginScreen.tsx
@@ -4,7 +4,11 @@ import * as React from 'react'
 import { initializeLogin } from '../../actions/LoginInitActions'
 import { updateFontStyles } from '../../constants/Fonts'
 import { Branding, ParentButton } from '../../types/Branding'
-import { OnLogin, OnNotificationPermit } from '../../types/ReduxTypes'
+import {
+  OnComplete,
+  OnLogin,
+  OnNotificationPermit
+} from '../../types/ReduxTypes'
 import { Router } from '../navigation/Router'
 import { ReduxStore } from '../services/ReduxStore'
 import { changeFont } from '../services/ThemeContext'
@@ -30,6 +34,10 @@ interface Props {
   // Options passed to the core login methods:
   accountOptions: EdgeAccountOptions
 
+  /**
+   * Called when the user navigates back passed the initialRoute if it was set.
+   */
+  onComplete?: OnComplete
   // Called when the login completes:
   onLogin: OnLogin
   // Called when the user makes a choice from RequestPermissionsModal:
@@ -56,6 +64,7 @@ export function LoginScreen(props: Props): JSX.Element {
     regularFontFamily,
     headingFontFamily = regularFontFamily
   } = fontDescription
+  const { onComplete = () => {} } = props
 
   // Always update legacy fonts:
   updateFontStyles(regularFontFamily, headingFontFamily)
@@ -81,7 +90,8 @@ export function LoginScreen(props: Props): JSX.Element {
       imports={{
         accountOptions: props.accountOptions,
         context: props.context,
-        onComplete: () => {},
+        initialRoute: props.initialRoute,
+        onComplete,
         onLogin: props.onLogin,
         onNotificationPermit: props.onNotificationPermit,
         recoveryKey: props.recoveryLogin,
@@ -89,7 +99,7 @@ export function LoginScreen(props: Props): JSX.Element {
         username: props.username,
         customPermissionsFunction: props.customPermissionsFunction
       }}
-      initialAction={initializeLogin(branding, props.initialRoute)}
+      initialAction={initializeLogin()}
     >
       <Router branding={branding} />
     </ReduxStore>

--- a/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
@@ -5,6 +5,7 @@ import { cacheStyles } from 'react-native-patina'
 import { sprintf } from 'sprintf-js'
 
 import { fetchIsUsernameAvailable } from '../../../actions/CreateAccountActions'
+import { maybeRouteComplete } from '../../../actions/LoginInitActions'
 import s from '../../../common/locales/strings'
 import { useHandler } from '../../../hooks/useHandler'
 import { Branding } from '../../../types/Branding'
@@ -19,15 +20,14 @@ import { ThemedScene } from '../../themed/ThemedScene'
 interface Props {
   branding: Branding
 }
-
 const AVAILABILITY_CHECK_DELAY_MS = 1000
 
 type Timeout = ReturnType<typeof setTimeout>
 
 export const NewAccountUsernameScene = ({ branding }: Props) => {
+  const dispatch = useDispatch()
   const theme = useTheme()
   const styles = getStyles(theme)
-  const dispatch = useDispatch()
 
   const mounted = React.useRef<boolean>(true)
   const [username, setUsername] = React.useState('')
@@ -68,12 +68,11 @@ export const NewAccountUsernameScene = ({ branding }: Props) => {
     errorText != null ||
     username.length === 0
 
+  const handleBack = useHandler(() => {
+    dispatch(maybeRouteComplete({ type: 'NEW_ACCOUNT_WELCOME' }))
+  })
   const handleNext = useHandler(async () => {
     dispatch(completeUsername(username))
-  })
-
-  const handleOnBack = useHandler(async () => {
-    await dispatch({ type: 'NEW_ACCOUNT_WELCOME' })
   })
 
   const handleChangeText = useHandler(async (text: string) => {
@@ -134,7 +133,7 @@ export const NewAccountUsernameScene = ({ branding }: Props) => {
   })
 
   return (
-    <ThemedScene onBack={handleOnBack} title={s.strings.choose_title_username}>
+    <ThemedScene onBack={handleBack} title={s.strings.choose_title_username}>
       <View style={styles.content}>
         <KeyboardAwareScrollView
           contentContainerStyle={styles.mainScrollView}


### PR DESCRIPTION
### CHANGELOG

- fixed: Re-implement accidentally reverted `onComplete` feature from 1.3.0

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
