### PR TITLE
Fix back on NewAccountPinScene

### DIFF
--- a/src/components/scenes/ChangePinScene.tsx
+++ b/src/components/scenes/ChangePinScene.tsx
@@ -153,7 +153,7 @@ export const NewAccountPinScene = () => {
   const dispatch = useDispatch()
 
   const handleBack = useHandler(() => {
-    maybeRouteComplete({ type: 'NEW_ACCOUNT_PASSWORD' })
+    dispatch(maybeRouteComplete({ type: 'NEW_ACCOUNT_PASSWORD' }))
   })
   const handleSubmit = useHandler(() => {
     logEvent('Signup_PIN_Valid')

--- a/src/components/scenes/PinLoginScene.tsx
+++ b/src/components/scenes/PinLoginScene.tsx
@@ -349,8 +349,6 @@ const getStyles = cacheStyles((theme: Theme) => ({
     justifyContent: 'space-around'
   },
   featureBox: {
-    position: 'relative',
-    top: theme.rem(2.5),
     width: '100%',
     alignItems: 'center'
   },


### PR DESCRIPTION
This fixes a couple of issues caused by the recent routing improvement work.

1. Too much space above the brand on the pin login scene was caused by adding a `ThemeScene` component.
2. A missing `dispatch` invocation was added for the `NewAccountPinScene`.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204381967043276