### PR TITLE
Change 2fa warning to let user know password is successful but 2fa locked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # edge-login-ui-rn
 
+## Unreleased
+
+- Changed: Reword IP OTP warning text
+
 ## 1.4.4 (2023-04-19)
 
 - fixed: Broken 'Confirm and Email' Recovery setup button

--- a/src/common/locales/strings/enUS.json
+++ b/src/common/locales/strings/enUS.json
@@ -181,7 +181,7 @@
   "alert_scene_approve": "It was me, grant access",
   "alert_scene_deny": "Not me, deny all",
   "otp_scene_header_2fa": "This device cannot log in because it does not have the right 2-factor code",
-  "otp_scene_header_ip": "This device cannot log in due to an unrecognized IP address",
+  "otp_scene_header_ip": "Username and password are correct. This device cannot log in due to an unrecognized IP address.",
   "otp_scene_approve": "Approve this request from another logged-in device",
   "otp_scene_qr": "Scan QR code with another logged-in device",
   "otp_scene_wait": "Wait until %s when this device will be automatically authorized to log in",


### PR DESCRIPTION
### CHANGELOG

- Changed: Reword IP OTP warning text

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203970962683348