### PR TITLE
Change TextInputModal to use KeyboardAwareScrollView

### DIFF
--- a/src/components/themed/ModalParts.tsx
+++ b/src/components/themed/ModalParts.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react'
-import {
-  ScrollView,
-  Text,
-  TouchableOpacity,
-  View,
-  ViewStyle
-} from 'react-native'
+import { Text, TouchableOpacity, View, ViewStyle } from 'react-native'
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { cacheStyles } from 'react-native-patina'
 import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 
@@ -112,14 +107,13 @@ export function ModalScrollArea(props: {
 
   return (
     <View>
-      <ScrollView
+      <KeyboardAwareScrollView
         contentContainerStyle={scrollPadding}
-        pagingEnabled
         style={styles.scrollViewContainer}
         keyboardShouldPersistTaps="handled"
       >
         {children}
-      </ScrollView>
+      </KeyboardAwareScrollView>
       <ModalFooter onPress={onCancel} fadeOut />
     </View>
   )


### PR DESCRIPTION
- Change TextInputModal to use KeyboardAwareScrollView

Additionally, pagingEnabled seems to conflict with
KeyboardAwareScrollView, causing a large overscroll/underscroll when
focusing/defocusing the control in iOS.

Unaddressed issues remain regarding Android/iOS inconsistency. iOS
specifically will auto-scroll the field when focused, but has strange
behavior where if invalid input is entered, the scroll behaves as if the
keyboard defocuses, even though the keyboard remains.

This fix at least addresses the bug of the close button overlapping the
submit button in all cases, but a larger scale change is required to
fully fix all cases of styling for android, ios, OutlinedTextInputFocus,
and KeyboardAwareScrollView.

### CHANGELOG

- fixed: Modal close button overlapping submit button in ChangeRecoveryScene modal

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204899024282615