### PR TITLE
Remove the ModalScrollArea from TextInputModal

### DIFF
--- a/src/components/modals/TextInputModal.tsx
+++ b/src/components/modals/TextInputModal.tsx
@@ -6,7 +6,7 @@ import s from '../../common/locales/strings'
 import { showError } from '../services/AirshipInstance'
 import { Alert } from '../themed/Alert'
 import { MainButton } from '../themed/MainButton'
-import { ModalMessage, ModalScrollArea, ModalTitle } from '../themed/ModalParts'
+import { ModalFooter, ModalMessage, ModalTitle } from '../themed/ModalParts'
 import { OutlinedTextInput } from '../themed/OutlinedTextInput'
 import { ThemedModal } from '../themed/ThemedModal'
 
@@ -99,57 +99,56 @@ export function TextInputModal(props: Props) {
   return (
     <ThemedModal warning={warning} bridge={bridge} onCancel={handleCancel}>
       {title == null ? null : <ModalTitle>{title}</ModalTitle>}
-      <ModalScrollArea onCancel={handleCancel}>
-        {message == null ? null : <ModalMessage>{message}</ModalMessage>}
-        {warningMessage == null ? null : (
-          <Alert
-            type="warning"
-            title={s.strings.warning}
-            marginRem={0.5}
-            message={warningMessage}
-            numberOfLines={0}
-          />
-        )}
-        <OutlinedTextInput
-          // Text input props:
-          autoCapitalize={autoCapitalize}
-          autoFocus={autoFocus}
-          autoCorrect={autoCorrect}
-          keyboardType={keyboardType}
-          label={inputLabel}
-          returnKeyType={returnKeyType}
-          secureTextEntry={secureTextEntry}
-          multiline={multiline}
-          // Our props:
-          error={errorMessage}
-          marginRem={[1, 0.5, 1.5, 0.5]}
-          onChangeText={handleChangeText}
-          onSubmitEditing={handleSubmit}
-          value={text}
-          maxLength={maxLength}
+      {message == null ? null : <ModalMessage>{message}</ModalMessage>}
+      {warningMessage == null ? null : (
+        <Alert
+          type="warning"
+          title={s.strings.warning}
+          marginRem={0.5}
+          message={warningMessage}
+          numberOfLines={0}
         />
-        {
-          // Hack around the android:windowSoftInputMode="adjustPan" glitch:
-          Platform.OS === 'android' ? <View style={{ flex: 2 }} /> : null
-        }
-        {spinning ? (
-          <MainButton
-            alignSelf="center"
-            disabled
-            marginRem={0.5}
-            type="secondary"
-            spinner
-          />
-        ) : (
-          <MainButton
-            alignSelf="center"
-            label={submitLabel}
-            marginRem={0.5}
-            onPress={handleSubmit}
-            type="secondary"
-          />
-        )}
-      </ModalScrollArea>
+      )}
+      <OutlinedTextInput
+        // Text input props:
+        autoCapitalize={autoCapitalize}
+        autoFocus={autoFocus}
+        autoCorrect={autoCorrect}
+        keyboardType={keyboardType}
+        label={inputLabel}
+        returnKeyType={returnKeyType}
+        secureTextEntry={secureTextEntry}
+        multiline={multiline}
+        // Our props:
+        error={errorMessage}
+        marginRem={[1, 0.5, 1.5, 0.5]}
+        onChangeText={handleChangeText}
+        onSubmitEditing={handleSubmit}
+        value={text}
+        maxLength={maxLength}
+      />
+      {
+        // Hack around the android:windowSoftInputMode="adjustPan" glitch:
+        Platform.OS === 'android' ? <View style={{ flex: 2 }} /> : null
+      }
+      {spinning ? (
+        <MainButton
+          alignSelf="center"
+          disabled
+          marginRem={[0.5, 0.5, 5, 0.5]}
+          type="secondary"
+          spinner
+        />
+      ) : (
+        <MainButton
+          alignSelf="center"
+          label={submitLabel}
+          marginRem={[0.5, 0.5, 5, 0.5]}
+          onPress={handleSubmit}
+          type="secondary"
+        />
+      )}
+      <ModalFooter onPress={handleCancel} fadeOut />
     </ThemedModal>
   )
 }


### PR DESCRIPTION
<img width="678" alt="image" src="https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/fcfdc803-3204-44a2-afe3-9074e87d3f69">
<img width="676" alt="image" src="https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/48c7bcf5-211e-449e-988c-20b5ef92caff">
<img width="679" alt="image" src="https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/47c69847-3fe5-4896-92d2-01625f6ed7c8">

### CHANGELOG

- fixed: Modal close button covering modal submit buttons while Android keyboard is open

### Dependencies

https://app.asana.com/0/1200382638405084/1204958636111638/f
https://app.asana.com/0/1200382638405084/1204984196051469/f

### Description

Remove the ModalScrollArea from TextInputModal.

A better fix would be to update our KeyboardAwareScrollView to something newer. 

There potentially exist new libraries such as @good-react-native/keyboard-avoider that properly handle different ScrollView configurations and iOS vs Android-specific issues like the bug addressed in this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204980372344820