### PR TITLE
Fix Password Login Dropdown List Visibility

### DIFF
--- a/src/components/scenes/PasswordLoginScene.tsx
+++ b/src/components/scenes/PasswordLoginScene.tsx
@@ -67,7 +67,6 @@ export const PasswordLoginScene = (props: Props) => {
   const styles = getStyles(theme)
 
   const localUsers = useLocalUsers()
-  const numUsers = localUsers.length
 
   const touch = useSelector(state => state.touch.type)
 
@@ -346,7 +345,7 @@ export const PasswordLoginScene = (props: Props) => {
   }, [contentHeight, scrollViewHeight])
 
   const renderUsername = () => {
-    const isMultiLocalUsers = numUsers > 1
+    const hasSavedUsers = localUsers.length > 0
 
     return (
       <View style={styles.usernameWrapper}>
@@ -354,7 +353,7 @@ export const PasswordLoginScene = (props: Props) => {
           <OutlinedTextInput
             autoCorrect={false}
             autoFocus
-            clearIcon={!isMultiLocalUsers}
+            clearIcon={!hasSavedUsers}
             error={usernameErrorMessage}
             label={s.strings.username}
             marginRem={[0.5, 1, 0.5, 1]}
@@ -364,7 +363,7 @@ export const PasswordLoginScene = (props: Props) => {
             onChangeText={handleChangeUsername}
           />
         </View>
-        {isMultiLocalUsers ? (
+        {hasSavedUsers ? (
           <TouchableOpacity
             testID="userDropdownIcon"
             style={styles.dropdownButton}


### PR DESCRIPTION
Enable the password login username dropdown for > 0 saved users (previously > 1 localUsers)

### CHANGELOG

- fixed: Enable the password login username dropdown for > 0 saved users (previously > 1 localUsers)

### Dependencies

https://github.com/EdgeApp/edge-login-ui-rn/pull/100

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
