### PR TITLE
Add an `initialLoginId` prop to the login screen

### DIFF
--- a/src/actions/LoginInitActions.tsx
+++ b/src/actions/LoginInitActions.tsx
@@ -18,7 +18,7 @@ import {
 } from '../components/modals/RequestPermissionsModal'
 import { SecurityAlertsModal } from '../components/modals/SecurityAlertsModal'
 import { Airship, showError } from '../components/services/AirshipInstance'
-import { arrangeUsers, upgradeUsers } from '../hooks/useLocalUsers'
+import { arrangeUsers, upgradeUser } from '../hooks/useLocalUsers'
 import { scene as sceneReducer } from '../reducers/SceneReducer'
 import { Branding } from '../types/Branding'
 import {
@@ -101,13 +101,15 @@ export const maybeRouteComplete = (fallbackAction: Action) => (
  * Loading is done, so send the user to the initial route.
  */
 function routeInitialization(state: RootState, imports: Imports): Action {
-  const { context, username } = imports
+  const {
+    context,
+    initialUserInfo = arrangeUsers(context.localUsers)[0]
+  } = imports
   const { touch } = state
 
   // Try to find the user requested by the LoginScene props:
-  const localUsers = upgradeUsers(arrangeUsers(context.localUsers), touch)
   const startupUser =
-    localUsers.find(user => user.username === username) ?? localUsers[0]
+    initialUserInfo != null ? upgradeUser(initialUserInfo, touch) : undefined
 
   const defaultInitialRoute = (): Action => {
     const { recoveryKey } = imports
@@ -151,7 +153,7 @@ function routeInitialization(state: RootState, imports: Imports): Action {
         type: 'NAVIGATE',
         data: {
           name: 'passwordLogin',
-          params: { username: imports.username ?? '' }
+          params: { username: startupUser?.username ?? '' }
         }
       }
     case 'new-account':

--- a/src/components/publicApi/LoginScreen.tsx
+++ b/src/components/publicApi/LoginScreen.tsx
@@ -16,6 +16,12 @@ import { AppConfig, InitialRouteName } from './types'
 
 interface Props {
   context: EdgeContext
+
+  /**
+   * The user to select, if present on the device.
+   * Get this from `EdgeContext.localUsers`
+   */
+  initialLoginId?: string
   initialRoute?: InitialRouteName
 
   // Branding stuff:
@@ -56,20 +62,37 @@ interface Props {
   // based on `hasSecurityAlerts` and `watchSecurityAlerts`:
   skipSecurityAlerts?: boolean
 
-  // The username to select, if present on the device:
-  username?: string
-
   // Call that overwrites the internal checkAndRequestNotifications function. Executed on Login initialization:
   customPermissionsFunction?: () => void
+
+  /**
+   * The username to select, if present on the device.
+   * @deprecated Use initialLoginId instead.
+   */
+  username?: string
 }
 
 export function LoginScreen(props: Props): JSX.Element {
-  const { appConfig, fontDescription = { regularFontFamily: 'System' } } = props
+  const {
+    appConfig,
+    context,
+    fontDescription = { regularFontFamily: 'System' },
+    initialLoginId,
+    username
+  } = props
   const {
     regularFontFamily,
     headingFontFamily = regularFontFamily
   } = fontDescription
   const { onComplete } = props
+
+  // Look up the requested user:
+  const initialUserInfo =
+    initialLoginId != null
+      ? context.localUsers.find(info => info.loginId === initialLoginId)
+      : username != null
+      ? context.localUsers.find(info => info.username === username)
+      : undefined
 
   // Update theme fonts if they are different:
   React.useEffect(() => changeFont(regularFontFamily, headingFontFamily), [
@@ -92,14 +115,14 @@ export function LoginScreen(props: Props): JSX.Element {
     <ReduxStore
       imports={{
         accountOptions: props.accountOptions,
-        context: props.context,
+        context,
+        initialUserInfo,
         initialRoute: props.initialRoute,
         onComplete,
         onLogin: props.onLogin,
         onNotificationPermit: props.onNotificationPermit,
         recoveryKey: props.recoveryLogin,
         skipSecurityAlerts: props.skipSecurityAlerts,
-        username: props.username,
         customPermissionsFunction: props.customPermissionsFunction
       }}
       initialAction={initializeLogin()}

--- a/src/components/scenes/LandingScene.tsx
+++ b/src/components/scenes/LandingScene.tsx
@@ -21,7 +21,7 @@ interface Props extends SceneProps<'landing'> {
 
 export const LandingScene = (props: Props) => {
   const dispatch = useDispatch()
-  const { username } = useImports()
+  const { initialUserInfo } = useImports()
 
   const handleCreate = useHandler(() => {
     logEvent('Signup_Create_Account')
@@ -36,7 +36,7 @@ export const LandingScene = (props: Props) => {
       type: 'NAVIGATE',
       data: {
         name: 'passwordLogin',
-        params: { username: username ?? '' }
+        params: { username: initialUserInfo?.username ?? '' }
       }
     })
   })

--- a/src/hooks/useLocalUsers.ts
+++ b/src/hooks/useLocalUsers.ts
@@ -16,10 +16,10 @@ export function useLocalUsers(): LoginUserInfo[] {
   const localUsers = useWatch(context, 'localUsers')
   const touch = useSelector(state => state.touch)
 
-  return React.useMemo(() => upgradeUsers(arrangeUsers(localUsers), touch), [
-    localUsers,
-    touch
-  ])
+  return React.useMemo(
+    () => arrangeUsers(localUsers).map(info => upgradeUser(info, touch)),
+    [localUsers, touch]
+  )
 }
 
 /**
@@ -50,19 +50,17 @@ export function arrangeUsers(localUsers: EdgeUserInfo[]): EdgeUserInfo[] {
   return [...recentUsers, ...oldUsers]
 }
 
-export function upgradeUsers(
-  localUsers: EdgeUserInfo[],
+export function upgradeUser(
+  userInfo: EdgeUserInfo,
   touch: TouchState
-): LoginUserInfo[] {
-  return localUsers.map(userInfo => {
-    const { username, keyLoginEnabled } = userInfo
-    return {
-      ...userInfo,
-      touchLoginEnabled:
-        username != null &&
-        keyLoginEnabled &&
-        touch.supported &&
-        typeof getKeychainStatus(touch.file, userInfo) === 'string'
-    }
-  })
+): LoginUserInfo {
+  const { username, keyLoginEnabled } = userInfo
+  return {
+    ...userInfo,
+    touchLoginEnabled:
+      username != null &&
+      keyLoginEnabled &&
+      touch.supported &&
+      typeof getKeychainStatus(touch.file, userInfo) === 'string'
+  }
 }

--- a/src/types/ReduxTypes.ts
+++ b/src/types/ReduxTypes.ts
@@ -1,5 +1,10 @@
 import { asBoolean, asJSON, asObject } from 'cleaners'
-import { EdgeAccount, EdgeAccountOptions, EdgeContext } from 'edge-core-js'
+import {
+  EdgeAccount,
+  EdgeAccountOptions,
+  EdgeContext,
+  EdgeUserInfo
+} from 'edge-core-js'
 import * as ReactRedux from 'react-redux'
 
 import { InitialRouteName } from '../components/publicApi/types'
@@ -40,13 +45,13 @@ export type OnNotificationPermit = (
 export interface Imports {
   readonly accountOptions: EdgeAccountOptions
   readonly context: EdgeContext
+  readonly initialUserInfo?: EdgeUserInfo
   readonly initialRoute?: InitialRouteName
   readonly onComplete?: () => void
   readonly onLogin?: OnLogin
   readonly onNotificationPermit?: OnNotificationPermit
   readonly recoveryKey?: string
   readonly skipSecurityAlerts?: boolean
-  readonly username?: string | null
   readonly customPermissionsFunction?: () => void
 }
 


### PR DESCRIPTION
This deprecates the old `username` prop, since we now have logins without usernames.

### CHANGELOG

- added: Accept an `initialLoginId` prop for the `LoginScreen`. Use this to select the initial user.
- deprecated: The `username` prop for the `LoginScreen`. Use `initialLoginId` instead.

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205085665980248