### PR TITLE
Stop mixing up keychain rows for light accounts

### DIFF
--- a/src/util/keychainFile.ts
+++ b/src/util/keychainFile.ts
@@ -39,11 +39,11 @@ export function getKeychainStatus(
   file: KeychainInfo[],
   account: EdgeAccount | EdgeUserInfo
 ): string | false | undefined {
+  const accountLoginId =
+    'rootLoginId' in account ? account.rootLoginId : account.loginId
   const row = file.find(row => {
-    const accountLoginId =
-      'rootLoginId' in account ? account.rootLoginId : account.loginId
-    if (row.loginId === accountLoginId) return true
-    if (row.username === account.username) return true
+    if (row.loginId != null && row.loginId === accountLoginId) return true
+    if (row.username != null && row.username === account.username) return true
     return false
   })
   return row?.key
@@ -61,8 +61,8 @@ export async function saveKeychainStatus(
   status: string | false | undefined
 ): Promise<void> {
   const newRows = file.filter(row => {
-    if (row.loginId === account.rootLoginId) return false
-    if (row.username === account.username) return false
+    if (row.loginId != null && row.loginId === account.rootLoginId) return false
+    if (row.username != null && row.username === account.username) return false
     return true
   })
 


### PR DESCRIPTION
### CHANGELOG

- fixed: Do not return incorrect keychain data for light accounts.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205116386089648