### PR TITLE
Update TOS wording for light accounts

### DIFF
--- a/src/common/locales/strings/enUS.json
+++ b/src/common/locales/strings/enUS.json
@@ -75,6 +75,7 @@
   "must_one_number": "Must have at least 1 number",
   "terms_one": "I understand that my funds are held securely on this device, not by %s",
   "terms_two": "I understand that if I lose this device or uninstall the app, my digital assets can only be recovered with my username and password",
+  "terms_two_alt": " I understand that if I lose my device or uninstall the app without first backing up my account with a username and password, my digital assets cannot be retrieved.",
   "terms_three": "I understand that if I lose my username and password, %s will not be able to recover my account, unless I set up password recovery",
   "terms_four": "I understand that I am responsible for safekeeping of my passwords, private key pairs, PIN, and any other codes to access the software. %s is not responsible if my information is compromised or accessed by a 3rd party where funds are lost",
   "choose_title_username": "Choose Username",

--- a/src/components/scenes/newAccount/NewAccountTosScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountTosScene.tsx
@@ -53,7 +53,7 @@ const TosComponent = (props: Props) => {
   const { appName = s.strings.app_name_default } = branding
   const terms: string[] = [
     sprintf(s.strings.terms_one, appName),
-    s.strings.terms_two,
+    hidePasswordTerms ? s.strings.terms_two_alt : s.strings.terms_two,
     ...(hidePasswordTerms ? [] : [sprintf(s.strings.terms_three, appName)]),
     sprintf(s.strings.terms_four, appName)
   ]


### PR DESCRIPTION
### CHANGELOG

- fixed: Invalid TOS wording for light (username-less) accounts

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205088164552539