### PR TITLE
Remove 2nd line from the TOS when setting light account PIN

### DIFF
--- a/src/common/locales/strings/enUS.json
+++ b/src/common/locales/strings/enUS.json
@@ -90,6 +90,7 @@
   "hide_account_info": "Hide account information",
   "password_desc": "Your password is used to encrypt your account and to log in.",
   "pin_desc": "Your PIN is a 4 digit code used to quickly log back into your account.\n\nPIN login is only usable on a device after first login with password.",
+  "pin_desc_alt": "Your PIN is a 4 digit code used to quickly log back into your account.",
   "recovery_token_invalid": "Invalid recovery token",
   "recovery_successful": "Recovery successful! Please change your password and PIN.",
   "recover_by_username": "Please enter the username of the account you want to recover.",

--- a/src/components/scenes/ChangePinScene.tsx
+++ b/src/components/scenes/ChangePinScene.tsx
@@ -21,6 +21,7 @@ import { MainButton } from '../themed/MainButton'
 import { ThemedScene } from '../themed/ThemedScene'
 
 interface Props {
+  body?: string
   initPin?: string
   title?: string
   onBack?: () => void
@@ -30,6 +31,7 @@ interface Props {
 }
 
 const ChangePinSceneComponent = ({
+  body = s.strings.pin_desc,
   initPin,
   title,
   onBack,
@@ -58,7 +60,7 @@ const ChangePinSceneComponent = ({
     <ThemedScene onBack={onBack} onSkip={onSkip} title={title}>
       <ScrollView ref={scrollViewRef} style={styles.content}>
         <EdgeText style={styles.description} numberOfLines={0}>
-          {s.strings.pin_desc}
+          {body}
         </EdgeText>
         <DigitInput pin={pin} onChangePin={handleChangePin} />
         <View style={styles.actions}>
@@ -195,6 +197,7 @@ export const NewAccountPinScene = (props: SceneProps<'newAccountPin'>) => {
 
   return (
     <ChangePinSceneComponent
+      body={lightAccount ? s.strings.pin_desc_alt : undefined}
       title={s.strings.choose_title_pin}
       onBack={handleBack}
       onSubmit={handleSubmit}


### PR DESCRIPTION
### CHANGELOG

- fixed: Remove 2nd line from the TOS when setting light (username-less) account PIN

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205128146166958