### PR TITLE
Don't clear modals upon unmounting UpgradeUsernameScreen

### DIFF
--- a/src/components/publicApi/UpgradeUsernameScreen.tsx
+++ b/src/components/publicApi/UpgradeUsernameScreen.tsx
@@ -1,7 +1,6 @@
 import { EdgeAccount, EdgeContext } from 'edge-core-js'
 import * as React from 'react'
 
-import { useClearOnUnmount } from '../../hooks/useClearOnUnmount'
 import { Router } from '../navigation/Router'
 import { ReduxStore } from '../services/ReduxStore'
 
@@ -13,8 +12,6 @@ interface Props {
 
 export function UpgradeUsernameScreen(props: Props): JSX.Element {
   const { account, context, onComplete } = props
-
-  useClearOnUnmount()
 
   return (
     <ReduxStore


### PR DESCRIPTION
### CHANGELOG

- fixed: Don't clear modals upon unmounting UpgradeUsernameScreen

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
