### PR TITLE
Jon/ab/create-login-buttons

### DIFF
--- a/src/common/locales/strings/enUS.json
+++ b/src/common/locales/strings/enUS.json
@@ -191,6 +191,7 @@
   "security_is_our_priority_modal_title": "Security is Our Priority",
   "send_email_error_header": "Can't send email",
   "show_account_info": "View account information",
+  "sign_up": "Sign Up",
   "skip_button": "Skip",
   "skip": "SKIP",
   "spin_load_hint": "Loading... please wait.",

--- a/src/components/publicApi/LoginScreen.tsx
+++ b/src/components/publicApi/LoginScreen.tsx
@@ -5,6 +5,7 @@ import { initializeLogin } from '../../actions/LoginInitActions'
 import { setAppConfig } from '../../common/appConfig'
 import { Branding, ParentButton } from '../../types/Branding'
 import {
+  ExperimentConfig,
   OnComplete,
   OnLogEvent,
   OnLogin,
@@ -59,6 +60,9 @@ interface Props {
 
   // The recoveryKey from the user's email, to trigger recovery login:
   recoveryLogin?: string
+
+  // Behavior and appearance management flags, for A/B testing.
+  experimentConfig?: ExperimentConfig
 
   // Do not show the security alerts screen during login,
   // since the app plans to show the `SecurityAlertsScreen` itself
@@ -127,6 +131,7 @@ export function LoginScreen(props: Props): JSX.Element {
         onNotificationPermit: props.onNotificationPermit,
         recoveryKey: props.recoveryLogin,
         skipSecurityAlerts: props.skipSecurityAlerts,
+        experimentConfig: props.experimentConfig,
         customPermissionsFunction: props.customPermissionsFunction
       }}
       initialAction={initializeLogin()}

--- a/src/components/scenes/ChangePinScene.tsx
+++ b/src/components/scenes/ChangePinScene.tsx
@@ -163,9 +163,9 @@ export const ResecurePinScene = (props: SceneProps<'resecurePin'>) => {
 export const NewAccountPinScene = (props: SceneProps<'newAccountPin'>) => {
   const { route } = props
   const dispatch = useDispatch()
-  const { onLogEvent = (event, values?) => {} } = useImports()
+  const { experimentConfig, onLogEvent = (event, values?) => {} } = useImports()
 
-  const lightAccount = route.params.username == null
+  const lightAccount = experimentConfig?.createAccountType === 'light'
 
   const handleBack = useHandler(() => {
     dispatch(

--- a/src/components/scenes/LandingScene.tsx
+++ b/src/components/scenes/LandingScene.tsx
@@ -8,6 +8,7 @@ import { useImports } from '../../hooks/useImports'
 import { Branding } from '../../types/Branding'
 import { useDispatch } from '../../types/ReduxTypes'
 import { SceneProps } from '../../types/routerTypes'
+import { getCreateAccountText } from '../../util/experiments'
 import { scale } from '../../util/scaling'
 import { LogoImageHeader } from '../abSpecific/LogoImageHeader'
 import { MainButton } from '../themed/MainButton'
@@ -20,8 +21,15 @@ interface Props extends SceneProps<'landing'> {
 
 export const LandingScene = (props: Props) => {
   const dispatch = useDispatch()
-  const { initialUserInfo } = useImports()
-  const { onLogEvent = (event, values?) => {} } = useImports()
+  const {
+    initialUserInfo,
+    experimentConfig,
+    onLogEvent = (event, values?) => {}
+  } = useImports()
+  const createAccText = React.useMemo(
+    () => getCreateAccountText(experimentConfig),
+    [experimentConfig]
+  )
 
   const handleCreate = useHandler(() => {
     onLogEvent('Signup_Create_Account')
@@ -57,7 +65,7 @@ export const LandingScene = (props: Props) => {
             <View style={styles.createButtonBox}>
               <MainButton
                 testID="createAccountButton"
-                label={s.strings.landing_create_account_button}
+                label={createAccText}
                 type="secondary"
                 onPress={handleCreate}
               />

--- a/src/components/scenes/PasswordLoginScene.tsx
+++ b/src/components/scenes/PasswordLoginScene.tsx
@@ -36,6 +36,7 @@ import { Branding } from '../../types/Branding'
 import { useDispatch, useSelector } from '../../types/ReduxTypes'
 import { SceneProps } from '../../types/routerTypes'
 import { base58 } from '../../util/base58'
+import { getCreateAccountText } from '../../util/experiments'
 import { LoginAttempt } from '../../util/loginAttempt'
 import { LogoImageHeader } from '../abSpecific/LogoImageHeader'
 import { UserListItem } from '../abSpecific/UserListItem'
@@ -70,9 +71,11 @@ export const PasswordLoginScene = (props: Props) => {
   const { username, createAccountType = 'full' } = route.params
   const {
     context,
+    experimentConfig,
     onComplete,
     onLogEvent = (event, values?) => {}
   } = useImports()
+
   const dispatch = useDispatch()
   const theme = useTheme()
   const styles = getStyles(theme)
@@ -101,6 +104,10 @@ export const PasswordLoginScene = (props: Props) => {
   const mDropContainerStyle = React.useMemo(() => {
     return { top: dropdownY, ...styles.dropContainer }
   }, [styles, dropdownY])
+  const createAccText = React.useMemo(
+    () => getCreateAccountText(experimentConfig),
+    [experimentConfig]
+  )
 
   const sAnimationMult = useSharedValue(0)
   const sScrollY = useSharedValue(0)
@@ -478,6 +485,7 @@ export const PasswordLoginScene = (props: Props) => {
 
   const renderButtons = () => {
     const buttonType = theme.preferPrimaryButton ? 'primary' : 'secondary'
+
     return (
       <View style={styles.buttonsBox}>
         <MainButton
@@ -503,7 +511,7 @@ export const PasswordLoginScene = (props: Props) => {
           type="textOnly"
           testID="createAccountButton"
           onPress={handleCreateAccount}
-          label={s.strings.create_an_account}
+          label={createAccText}
         />
         <TouchableOpacity onPress={handleQrModal}>
           <AntDesignIcon

--- a/src/components/scenes/newAccount/NewAccountTosScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountTosScene.tsx
@@ -191,8 +191,12 @@ export const NewAccountTosScene = (props: NewAccountTosProps) => {
   const imports = useImports()
   const {
     context,
+
     accountOptions,
+    experimentConfig,
+
     onLogin,
+
     onLogEvent = (event, values?) => {}
   } = imports
   const dispatch = useDispatch()
@@ -206,7 +210,8 @@ export const NewAccountTosScene = (props: NewAccountTosProps) => {
 
   const handleNext = useHandler(async () => {
     const { username, password, pin } = route.params
-    const lightAccount = username == null
+
+    const lightAccount = experimentConfig?.createAccountType === 'light'
 
     let error
     try {

--- a/src/types/ReduxTypes.ts
+++ b/src/types/ReduxTypes.ts
@@ -37,6 +37,11 @@ export interface TouchIdInfo {
   isTouchEnabled: boolean
 }
 
+export interface ExperimentConfig {
+  // createAccountType: 'light' | 'full' // TODO
+  createAccountText: 'signUp' | 'getStarted' | 'createAccount'
+}
+
 export type OnComplete = () => void
 export type OnLogin = (account: EdgeAccount, touchIdInfo?: TouchIdInfo) => void
 export type OnNotificationPermit = (
@@ -58,6 +63,7 @@ export interface Imports {
   readonly onNotificationPermit?: OnNotificationPermit
   readonly recoveryKey?: string
   readonly skipSecurityAlerts?: boolean
+  readonly experimentConfig?: ExperimentConfig
   readonly customPermissionsFunction?: () => void
 }
 

--- a/src/types/ReduxTypes.ts
+++ b/src/types/ReduxTypes.ts
@@ -38,7 +38,7 @@ export interface TouchIdInfo {
 }
 
 export interface ExperimentConfig {
-  // createAccountType: 'light' | 'full' // TODO
+  createAccountType: 'light' | 'full'
   createAccountText: 'signUp' | 'getStarted' | 'createAccount'
 }
 

--- a/src/util/experiments.ts
+++ b/src/util/experiments.ts
@@ -1,0 +1,25 @@
+import s from '../common/locales/strings'
+import { ExperimentConfig } from '../types/ReduxTypes'
+
+export const getExperimentVal = <T extends keyof ExperimentConfig>(
+  experimentCfg: ExperimentConfig | undefined,
+  key: T,
+  defaultVal: ExperimentConfig[T]
+): ExperimentConfig[T] => {
+  return experimentCfg && experimentCfg[key] ? experimentCfg[key] : defaultVal
+}
+
+export const getCreateAccountText = (
+  experimentCfg: ExperimentConfig | undefined
+): string => {
+  const createAccTextVar = getExperimentVal(
+    experimentCfg,
+    'createAccountText',
+    'createAccount'
+  )
+  return createAccTextVar === 'signUp'
+    ? s.strings.sign_up
+    : createAccTextVar === 'getStarted'
+    ? s.strings.get_started
+    : s.strings.create_an_account
+}


### PR DESCRIPTION
### CHANGELOG

- added: 'Create Account' button text experiment

### Dependencies

https://github.com/EdgeApp/edge-login-ui-rn/pull/131

### Description

3 variants to rename "Create Account" buttons to:
- Sign Up
- Get Started
- Create Account (unchanged)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205532906159295