### PR TITLE
Fix breaking api changes (onLogEvent)

### DIFF
--- a/src/components/publicApi/SecurityAlertsScreen.tsx
+++ b/src/components/publicApi/SecurityAlertsScreen.tsx
@@ -10,7 +10,7 @@ interface Props {
   account: EdgeAccount
   context: EdgeContext
   onComplete: () => void
-  onLogEvent: OnLogEvent
+  onLogEvent?: OnLogEvent
 }
 
 export function SecurityAlertsScreen(props: Props): JSX.Element {

--- a/src/components/publicApi/UpgradeUsernameScreen.tsx
+++ b/src/components/publicApi/UpgradeUsernameScreen.tsx
@@ -9,7 +9,7 @@ interface Props {
   account: EdgeAccount
   context: EdgeContext
   onComplete: () => void
-  onLogEvent: OnLogEvent
+  onLogEvent?: OnLogEvent
 }
 
 export function UpgradeUsernameScreen(props: Props): JSX.Element {


### PR DESCRIPTION
Some screens still had mandatory onLogEvent props

### CHANGELOG

- fixed: Unintended breaking API changes from 2.13.0

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205575774412390