### PR TITLE
Rename RadioListModal -> QuestionListModal, update ListModal props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # edge-login-ui-rn
 
+## Unreleased
+
+- fixed: Search box incorrectly showing in Password recovery questions modal
+- changed: ListModal props updated: `textInput`->`hideSearch`
+
 ## 2.15.0 (2023-10-23)
 
 - added: Signup captcha experiment.

--- a/src/components/modals/ListModal.tsx
+++ b/src/components/modals/ListModal.tsx
@@ -22,7 +22,7 @@ interface Props<T> {
   // Header Props
   title?: string
   message?: string
-  textInput?: boolean // Defaults to 'true'
+  hideSearch?: boolean // Defaults to 'false'
   initialValue?: string // Defaults to ''
   // OutlinedTextInput properties:
   searchIcon?: boolean // Defaults to 'true'
@@ -61,7 +61,7 @@ export function ListModal<T>({
   bridge,
   title,
   message,
-  textInput = true,
+  hideSearch = false,
   initialValue = '',
   rowsData = [],
   fullScreen = true,
@@ -98,7 +98,7 @@ export function ListModal<T>({
     >
       {title == null ? null : <ModalTitle>{title}</ModalTitle>}
       {message == null ? null : <ModalMessage>{message}</ModalMessage>}
-      {textInput == null ? null : (
+      {hideSearch ? null : (
         <OutlinedTextInput
           // Our props:
           searchIcon

--- a/src/components/modals/QuestionListModal.tsx
+++ b/src/components/modals/QuestionListModal.tsx
@@ -15,7 +15,7 @@ interface Props {
   selected?: string
 }
 
-export function RadioListModal(props: Props) {
+export function QuestionListModal(props: Props) {
   const { bridge, items, selected, title } = props
   const theme = useTheme()
   const styles = getStyles(theme)
@@ -48,7 +48,7 @@ export function RadioListModal(props: Props) {
     <ListModal
       bridge={bridge}
       title={title}
-      textInput={false}
+      hideSearch
       rowsData={items}
       // @ts-expect-error
       rowComponent={renderRow}

--- a/src/components/scenes/existingAccout/ChangeRecoveryScene.tsx
+++ b/src/components/scenes/existingAccout/ChangeRecoveryScene.tsx
@@ -21,7 +21,7 @@ import { Tile } from '../../common/Tile'
 import { WarningCard } from '../../common/WarningCard'
 import { ButtonsModal } from '../../modals/ButtonsModal'
 import { DateModal } from '../../modals/DateModal'
-import { RadioListModal } from '../../modals/RadioListModal'
+import { QuestionListModal } from '../../modals/QuestionListModal'
 import { TextInputModal } from '../../modals/TextInputModal'
 import { Airship, showError } from '../../services/AirshipInstance'
 import { Theme, useTheme } from '../../services/ThemeContext'
@@ -82,7 +82,7 @@ export const ChangeRecoveryScene = (props: Props) => {
 
     const items = questionsList.map(extractQuestion).filter(stringPredicate)
     Airship.show<string | undefined>(bridge => (
-      <RadioListModal
+      <QuestionListModal
         bridge={bridge}
         title={sprintf(lstrings.recovery_question, index + 1)}
         items={items.filter(


### PR DESCRIPTION
Rename RadioListModal->QuestionListModal. Remove search bar from modal.

Make ListModal props more specific to the functionality - hideSearch. Remove the need to specify a value when setting hideSearch.

ListModal changes to be mirrored in edge-react-gui.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/edge-react-gui/pull/4551

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205773982652040