### PR TITLE
LoginUi: Fix QuestionListModal + ChangeRecoveryScene

### DIFF
--- a/src/components/modals/QuestionListModal.tsx
+++ b/src/components/modals/QuestionListModal.tsx
@@ -20,7 +20,7 @@ export function QuestionListModal(props: Props) {
   const theme = useTheme()
   const styles = getStyles(theme)
 
-  function renderRow(item: string): React.ReactNode {
+  function renderRow(item: string): JSX.Element {
     const radio = {
       icon: `ios-radio-button-${selected === item ? 'on' : 'off'}`,
       color: theme.iconTappable
@@ -48,10 +48,9 @@ export function QuestionListModal(props: Props) {
     <ListModal
       bridge={bridge}
       title={title}
-      hideSearch
+      textInput={false}
       rowsData={items}
-      // @ts-expect-error
-      rowComponent={renderRow}
+      rowComponent={(item: string) => renderRow(item)}
       fullScreen={false}
     />
   )

--- a/src/components/scenes/existingAccout/ChangeRecoveryScene.tsx
+++ b/src/components/scenes/existingAccout/ChangeRecoveryScene.tsx
@@ -326,13 +326,15 @@ export const ChangeRecoveryScene = (props: Props) => {
       <WarningCard title={lstrings.answer_case_sensitive} marginRem={1} />
     ) : null
   }
+
+  // TODO: Need to rework buttons for UI4
   const renderModifyButtons = () => {
     return (
       <View style={styles.buttonsContainer}>
         <MainButton
           alignSelf="center"
+          marginRem={0}
           label={lstrings.recovery_change_button}
-          marginRem={1}
           onPress={changeRecovery}
           type="primary"
         />
@@ -350,25 +352,25 @@ export const ChangeRecoveryScene = (props: Props) => {
     return (
       <View style={styles.buttonsContainer}>
         <MainButton
-          alignSelf="stretch"
+          alignSelf="center"
           label={lstrings.confirm_email}
-          marginRem={[1, 0, 0.5, 0]}
+          marginRem={0.25}
           onPress={saveRecoveryViaEmail}
           disabled={!confirmButtonsEnabled}
           type="primary"
         />
         <MainButton
-          alignSelf="stretch"
+          alignSelf="center"
           label={lstrings.confirm_share}
-          marginRem={[0.5, 0]}
+          marginRem={0.25}
           onPress={saveRecoveryViaShare}
           disabled={!confirmButtonsEnabled}
           type="primary"
         />
         <MainButton
-          alignSelf="stretch"
+          alignSelf="center"
           label={lstrings.cancel}
-          paddingRem={[1, 0]}
+          marginRem={[0.25, 0, 1]}
           onPress={onComplete}
           type="escape"
         />
@@ -409,7 +411,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
   },
   disableButtonContainer: {
     alignSelf: 'center',
-    paddingVertical: theme.rem(1)
+    marginVertical: theme.rem(1)
   },
   disableButton: {
     color: theme.dangerText,


### PR DESCRIPTION
![image](https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/82195f36-01ff-45aa-acd8-2c613e474e6d)
![image](https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/9bef292c-5a1e-49a5-88a3-558e48c8998f)
![image](https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/ada2b896-98a8-4f9c-aaaa-86e608cd8763)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

There's a bug in ButtonUi4 where the margins/padding are being applied twice.

This issue is not apparent when using ButtonsViewUi4 because no custom margins/padding is being applied in that case.

Since we're hacking buttons for display on this scene, and the fact that we incorrectly have two equal primary actions, just apply custom margins that make it work to avoid regressions for other callers.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206425714003075