### PR TITLE
Do not let the modal gesture block the CAPTCHA

### DIFF
--- a/src/components/modals/ChallengeModal.tsx
+++ b/src/components/modals/ChallengeModal.tsx
@@ -40,10 +40,12 @@ export const ChallengeModal = (props: Props) => {
   return (
     <ModalUi4
       bridge={bridge}
+      noSwiping
       title={lstrings.complete_captcha_title}
       onCancel={handleCancel}
     >
       <WebView
+        javaScriptEnabled
         source={
           challengeError == null
             ? { html: abTestDummyPage }

--- a/src/components/ui4/ModalUi4.tsx
+++ b/src/components/ui4/ModalUi4.tsx
@@ -41,6 +41,9 @@ export interface ModalPropsUi4<T = unknown> {
 
   children?: React.ReactNode
 
+  // Disable the swipe-to-close gesture:
+  noSwiping?: boolean
+
   // Include a scroll area:
   scroll?: boolean
 
@@ -64,6 +67,7 @@ export function ModalUi4<T>(props: ModalPropsUi4<T>): JSX.Element {
     bridge,
     title,
     children,
+    noSwiping = false,
     scroll = false,
     warning = false,
     onCancel
@@ -123,6 +127,7 @@ export function ModalUi4<T>(props: ModalPropsUi4<T>): JSX.Element {
   }, [handleCancel])
 
   const gesture = Gesture.Pan()
+    .enabled(!noSwiping)
     .onUpdate(e => {
       offset.value = e.translationY
     })


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

The swipe-to-close gesture on the modal was capturing touch events, preventing the WebView from seeing the swipe.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206586782428604