### PR TITLE
Convert the ChallengeModal to a legacy Airship modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Solve additional CAPTCHA-modal glitches on Android.
+
 ## 3.3.3 (2024-02-15)
 
 - fixed: Header button height increase to give more room from the screen's top edge

--- a/src/components/modals/ChallengeModal.tsx
+++ b/src/components/modals/ChallengeModal.tsx
@@ -1,14 +1,19 @@
-/**
- * IMPORTANT: Changes in this file MUST be duplicated in edge-react-gui!
- */
 import type { ChallengeError } from 'edge-core-js'
 import * as React from 'react'
-import { AirshipBridge } from 'react-native-airship'
+import {
+  ActivityIndicator,
+  StyleSheet,
+  TouchableOpacity,
+  View
+} from 'react-native'
+import { AirshipBridge, AirshipModal } from 'react-native-airship'
+import AntDesignIcon from 'react-native-vector-icons/AntDesign'
 import { WebView, WebViewNavigation } from 'react-native-webview'
 
 import { lstrings } from '../../common/locales/strings'
 import { useHandler } from '../../hooks/useHandler'
-import { ModalUi4 } from '../ui4/ModalUi4'
+import { cacheStyles, Theme, useTheme } from '../services/ThemeContext'
+import { EdgeText } from '../themed/EdgeText'
 
 interface Props {
   bridge: AirshipBridge<boolean | undefined>
@@ -16,10 +21,21 @@ interface Props {
   challengeError?: ChallengeError
 }
 
+// The Edge login servers return a CAPTCHA page with fixed colors.
+// We want the modal to match the colors on the page,
+// regardless of the current theme:
+const SERVER_TEXT_COLOR = 'white'
+const SERVER_BACKGROUND_COLOR = '#121d25'
+
 export const ChallengeModal = (props: Props) => {
   const { bridge, challengeError } = props
+  const theme = useTheme()
+  const styles = getStyles(theme)
+
+  const [loading, setLoading] = React.useState(true)
 
   const handleCancel = useHandler(() => bridge.resolve(undefined))
+  const handleLoad = useHandler(() => setLoading(false))
   const handleLoading = useHandler((event: WebViewNavigation): boolean => {
     if (/\/success$/.test(event.url)) {
       bridge.resolve(true)
@@ -32,18 +48,30 @@ export const ChallengeModal = (props: Props) => {
     return true
   })
 
-  // Allow the modal background to appear inside the WebView.
-  // This is a magic value from the WebView documentation,
-  // so don't use the theme - normal colors don't do anything.
-  const webviewStyle = { backgroundColor: '#00000000' }
-
   return (
-    <ModalUi4
+    <AirshipModal
+      backgroundColor={SERVER_BACKGROUND_COLOR}
       bridge={bridge}
-      noSwiping
-      title={lstrings.complete_captcha_title}
+      // Create a gap on top of the modal, so the user can tap to dismiss:
+      margin={[theme.rem(5), 0, 0]}
+      padding={theme.rem(0.5)}
       onCancel={handleCancel}
     >
+      <View style={styles.titleContainer}>
+        <EdgeText style={styles.titleText} numberOfLines={2}>
+          {lstrings.complete_captcha_title}
+        </EdgeText>
+        <TouchableOpacity
+          style={styles.closeIconContainer}
+          onPress={handleCancel}
+        >
+          <AntDesignIcon
+            name="close"
+            color={SERVER_TEXT_COLOR}
+            size={theme.rem(1.25)}
+          />
+        </TouchableOpacity>
+      </View>
       <WebView
         javaScriptEnabled
         source={
@@ -51,12 +79,54 @@ export const ChallengeModal = (props: Props) => {
             ? { html: abTestDummyPage }
             : { uri: challengeError.challengeUri }
         }
-        style={webviewStyle}
+        style={styles.webview}
+        onLoad={handleLoad}
         onShouldStartLoadWithRequest={handleLoading}
       />
-    </ModalUi4>
+      {!loading ? null : (
+        <View pointerEvents="box-none" style={styles.overlay}>
+          <ActivityIndicator color={SERVER_TEXT_COLOR} size="large" />
+        </View>
+      )}
+    </AirshipModal>
   )
 }
+
+const getStyles = cacheStyles((theme: Theme) => ({
+  closeIconContainer: {
+    margin: theme.rem(-0.5),
+    padding: theme.rem(0.5)
+  },
+
+  titleContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    margin: theme.rem(0.5)
+  },
+
+  titleText: {
+    color: SERVER_TEXT_COLOR,
+    flexShrink: 1,
+    fontFamily: theme.fontFaceMedium,
+    fontSize: theme.rem(1.2)
+  },
+
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+
+  // eslint-disable-next-line react-native/no-color-literals
+  webview: {
+    alignSelf: 'stretch',
+    margin: theme.rem(0.5),
+    // Allow the modal background to appear inside the WebView.
+    // This is a magic value from the WebView documentation,
+    // so don't use the theme - normal colors don't do anything.
+    backgroundColor: '#00000000'
+  }
+}))
 
 const abTestDummyPage = `<!DOCTYPE html>
 <html><head>
@@ -195,6 +265,5 @@ const abTestDummyPage = `<!DOCTYPE html>
       }
       setup();
     </script>
-  
-
-</body></html>`
+</body></html>
+`

--- a/src/components/scenes/newAccount/NewAccountTosScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountTosScene.tsx
@@ -14,7 +14,8 @@ import { Branding } from '../../../types/Branding'
 import { useDispatch } from '../../../types/ReduxTypes'
 import { SceneProps } from '../../../types/routerTypes'
 import { EdgeAnim } from '../../common/EdgeAnim'
-import { showChallengeModal, showError } from '../../services/AirshipInstance'
+import { ChallengeModal } from '../../modals/ChallengeModal'
+import { Airship, showError } from '../../services/AirshipInstance'
 import { Theme, useTheme } from '../../services/ThemeContext'
 import { Checkbox } from '../../themed/Checkbox'
 import { EdgeText } from '../../themed/EdgeText'
@@ -177,7 +178,9 @@ export const NewAccountTosScene = (props: NewAccountTosProps) => {
   const handleNext = useHandler(async () => {
     if (experimentConfig.signupCaptcha === 'withCaptcha') {
       onLogEvent('Signup_Captcha_Shown')
-      const result = await showChallengeModal()
+      const result = await Airship.show<boolean | undefined>(bridge => (
+        <ChallengeModal bridge={bridge} />
+      ))
 
       // User closed the modal
       if (result == null) {

--- a/src/components/services/AirshipInstance.tsx
+++ b/src/components/services/AirshipInstance.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { AirshipToast, makeAirship } from 'react-native-airship'
 
 import { AlertDropdown } from '../common/AlertDropdown'
-import { ChallengeModal } from '../modals/ChallengeModal'
 
 export const Airship = makeAirship()
 
@@ -35,10 +34,4 @@ export function showWarning(message: string): void {
  */
 export function showToast(message: string): void {
   Airship.show(bridge => <AirshipToast bridge={bridge} message={message} />)
-}
-
-export const showChallengeModal = async () => {
-  return await Airship.show<boolean | undefined>(bridge => (
-    <ChallengeModal bridge={bridge} />
-  ))
 }


### PR DESCRIPTION
We cannot use the new modal, because the react-native-gesture-handler and blur features are messing with the WebView on Android. The blur seems to be re-rendering each time the WebView contents change, which is making the puzzle piece slider super-janky. Finally, there seems to be a layout issue that is making the WebView content invisible to start (but only on Android). We already had to disable the modal-close gesture in an earlier PR.

Rather than deal with these problems, let's put it back the way it was.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

![simulator_screenshot_C72B6397-5F42-4198-97FA-614EB7038293](https://github.com/EdgeApp/edge-login-ui-rn/assets/276214/0e7fd3be-9b44-410c-a567-b4bdbe645ce0)

![Screenshot_20240216_113049](https://github.com/EdgeApp/edge-login-ui-rn/assets/276214/91b9bfd7-6ca9-4027-9ccd-ebecb43416a6)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206605010112118