### PR TITLE
Reposition spacing of header elements for ThemedScene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fixed: Adjust header button styling to fix spacing regressions on some scenes
 - fixed: Solve additional CAPTCHA-modal glitches on Android.
 
 ## 3.3.3 (2024-02-15)

--- a/src/components/scenes/PinLoginScene.tsx
+++ b/src/components/scenes/PinLoginScene.tsx
@@ -461,10 +461,11 @@ const getStyles = cacheStyles((theme: Theme) => ({
     backgroundColor: theme.modal
   },
   featureBoxContainer: {
-    width: '100%',
     flex: 1,
     flexDirection: 'column',
-    justifyContent: 'space-around'
+    justifyContent: 'space-around',
+    paddingTop: theme.rem(2),
+    width: '100%'
   },
   featureBox: {
     width: '100%',

--- a/src/components/themed/ThemedScene.tsx
+++ b/src/components/themed/ThemedScene.tsx
@@ -111,12 +111,15 @@ export function ThemedScene(props: Props) {
 }
 
 const getStyles = cacheStyles((theme: Theme) => {
-  const buttonHeight = theme.rem(4.5)
+  // Roughly the same as the height as the GUI.
+  // The GUI uses react-navigation's getDefaultHeaderHeight to get the
+  // platform-specific height.
+  const buttonHeight = theme.rem(2.5)
 
   return {
     headerButtons: {
       flexDirection: 'row',
-      height: buttonHeight
+      justifyContent: 'space-between'
     },
     leftButton: {
       alignItems: 'center',
@@ -124,10 +127,7 @@ const getStyles = cacheStyles((theme: Theme) => {
       justifyContent: 'center',
       paddingHorizontal: theme.rem(1),
       minWidth: theme.rem(3),
-      minHeight: buttonHeight,
-      position: 'absolute',
-      left: 0,
-      top: theme.rem(-1)
+      minHeight: buttonHeight
     },
     rightButton: {
       alignItems: 'center',
@@ -135,10 +135,7 @@ const getStyles = cacheStyles((theme: Theme) => {
       justifyContent: 'center',
       paddingHorizontal: theme.rem(1),
       minWidth: theme.rem(3),
-      minHeight: buttonHeight,
-      position: 'absolute',
-      right: 0,
-      top: theme.rem(-1)
+      minHeight: buttonHeight
     },
     buttonIcon: {
       color: theme.primaryText,


### PR DESCRIPTION
This fixes weird spacing issue on certain scenes and makes the header
more consistently vertically sized.
We've added the extra padding to the PinLoginScene to match the padding
of the PasswordLoginScene.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206672583193526