### PR TITLE
Add missing changes from last PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- changed: Sync ButtonUi4, FilledTextInput, and Touchable components with edge-react-gui
 - fixed: Export missing type definitions.
 
 ## 3.5.0 (2024-03-01)

--- a/src/components/modals/TextInputModal.tsx
+++ b/src/components/modals/TextInputModal.tsx
@@ -144,16 +144,9 @@ export function TextInputModal(props: Props) {
         Platform.OS === 'android' ? <View style={{ flex: 2 }} /> : null
       }
       {spinning ? (
-        <MainButton
-          alignSelf="center"
-          disabled
-          marginRem={0.5}
-          type="secondary"
-          spinner
-        />
+        <MainButton disabled marginRem={0.5} type="secondary" spinner />
       ) : (
         <MainButton
-          alignSelf="center"
           label={submitLabel}
           marginRem={0.5}
           onPress={handleSubmit}

--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -183,16 +183,9 @@ const ChangePasswordSceneComponent = ({
           visible={!isShowError}
         >
           {spinning ? (
-            <MainButton
-              alignSelf="center"
-              disabled
-              marginRem={0.5}
-              type="primary"
-              spinner
-            />
+            <MainButton disabled marginRem={0.5} type="primary" spinner />
           ) : (
             <MainButton
-              alignSelf="center"
               label={mainButtonLabel}
               disabled={!isRequirementsMet || confirmPassword === ''}
               marginRem={0.5}

--- a/src/components/scenes/RecoveryLoginScene.tsx
+++ b/src/components/scenes/RecoveryLoginScene.tsx
@@ -163,7 +163,6 @@ export const RecoveryLoginScene = (props: SceneProps<'recoveryLogin'>) => {
     return (
       <View style={styles.buttonsContainer}>
         <MainButton
-          alignSelf="stretch"
           label={lstrings.submit}
           marginRem={[1, 0.5]}
           onPress={handleSubmit}

--- a/src/components/scenes/existingAccout/ChangeRecoveryScene.tsx
+++ b/src/components/scenes/existingAccout/ChangeRecoveryScene.tsx
@@ -332,7 +332,6 @@ export const ChangeRecoveryScene = (props: Props) => {
     return (
       <View style={styles.buttonsContainer}>
         <MainButton
-          alignSelf="center"
           marginRem={0}
           label={lstrings.recovery_change_button}
           onPress={changeRecovery}
@@ -352,7 +351,6 @@ export const ChangeRecoveryScene = (props: Props) => {
     return (
       <View style={styles.buttonsContainer}>
         <MainButton
-          alignSelf="center"
           label={lstrings.confirm_email}
           marginRem={0.25}
           onPress={saveRecoveryViaEmail}
@@ -360,7 +358,6 @@ export const ChangeRecoveryScene = (props: Props) => {
           type="primary"
         />
         <MainButton
-          alignSelf="center"
           label={lstrings.confirm_share}
           marginRem={0.25}
           onPress={saveRecoveryViaShare}
@@ -368,7 +365,6 @@ export const ChangeRecoveryScene = (props: Props) => {
           type="primary"
         />
         <MainButton
-          alignSelf="center"
           label={lstrings.cancel}
           marginRem={[0.25, 0, 1]}
           onPress={onComplete}

--- a/src/components/themed/MainButton.tsx
+++ b/src/components/themed/MainButton.tsx
@@ -12,10 +12,6 @@ interface Props {
   // and show a spinner until the promise resolves.
   onPress?: () => void | Promise<void>
 
-  // Whether to center the button or stretch to fill the screen.
-  // Defaults to 'auto', letting the parent component be in charge:
-  alignSelf?: 'auto' | 'stretch' | 'center'
-
   // True to dim the button & prevent interactions:
   disabled?: boolean
 
@@ -47,7 +43,6 @@ interface Props {
  */
 export function MainButton(props: Props) {
   const {
-    alignSelf = 'auto',
     children,
     disabled = false,
     label,
@@ -62,7 +57,6 @@ export function MainButton(props: Props) {
 
   return (
     <ButtonUi4
-      alignSelf={alignSelf}
       disabled={disabled}
       label={label}
       marginRem={marginRem}


### PR DESCRIPTION
Did not push: CHANGELOG and 'align' prop removal.
'align' is safe to remove because we already did in GUI, and the prop always gets overridden anyway no matter what the caller sets.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/edge-login-ui-rn/pull/173

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
