### PR TITLE
Update styling and implement new password validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- changed: Move "password match" check to the "Password Requirements" Card
 - fixed: Unable to highlight password input fields when content is toggled visible
 
 ## 3.6.1 (2024-03-13)

--- a/src/common/locales/strings/enUS.json
+++ b/src/common/locales/strings/enUS.json
@@ -134,7 +134,7 @@
   "password_change_warning": "Changing your password doesn't protect compromised accounts that have already been accessed. If you believe your account has an unknown login please move remaining funds to a new account. \n\nDo not send funds to the compromised account.",
   "password_changed": "Password Changed",
   "password_desc": "Your password is used to encrypt your account and to log in.",
-  "password_mismatch_error": "Passwords don't match",
+  "password_must_match": "Passwords must match",
   "password_recovery": "Password Recovery",
   "password_requirements": "Password Requirements",
   "password": "Password",

--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -1,6 +1,7 @@
 import { EdgeAccount, EdgePasswordRules } from 'edge-core-js'
 import * as React from 'react'
-import { Keyboard, KeyboardAvoidingView } from 'react-native'
+import { Keyboard } from 'react-native'
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { cacheStyles } from 'react-native-patina'
 
 import { lstrings } from '../../common/locales/strings'
@@ -65,10 +66,16 @@ const ChangePasswordSceneComponent = ({
   const [focusSecond, setFocusSecond] = React.useState(false)
   const [spinning, setSpinning] = React.useState(false)
   const [isShowError, setIsShowError] = React.useState(false)
-  const [passwordEval, setPasswordEval] = React.useState<
-    EdgePasswordRules | undefined
-  >(undefined)
-  const isRequirementsMet = passwordEval?.passed ?? false
+  const [passwordEval, setPasswordEval] = React.useState<EdgePasswordRules>({
+    secondsToCrack: 0, // unused
+    passed: false,
+    tooShort: true,
+    noLowerCase: true,
+    noUpperCase: true,
+    noNumber: true
+  })
+
+  const isRequirementsMet = passwordEval.passed
 
   const [password, setPassword] = React.useState(initPassword ?? '')
   const [confirmPassword, setConfirmPassword] = React.useState('')
@@ -76,7 +83,6 @@ const ChangePasswordSceneComponent = ({
     confirmPasswordErrorMessage,
     setConfirmPasswordErrorMessage
   ] = React.useState('')
-
   const handlePress = useHandler(async () => {
     if (!isRequirementsMet) return
     if (password !== confirmPassword) {
@@ -118,25 +124,26 @@ const ChangePasswordSceneComponent = ({
   const renderInterior = () => {
     return (
       <>
-        {passwordEval != null ? (
-          <PasswordStatus
-            marginRem={[0.5, 0.5, 1.25]}
-            passwordEval={passwordEval}
-          />
-        ) : (
-          <EdgeAnim
-            enter={{ type: 'fadeInUp', distance: 50 }}
-            exit={{ type: 'fadeOutDown' }}
-          >
-            <EdgeText style={styles.description} numberOfLines={4}>
-              {lstrings.password_desc}
-            </EdgeText>
-          </EdgeAnim>
-        )}
+        <EdgeAnim
+          enter={{ type: 'fadeInUp', distance: 50 }}
+          exit={{ type: 'fadeOutDown' }}
+        >
+          <EdgeText style={styles.description} numberOfLines={4}>
+            {lstrings.password_desc}
+          </EdgeText>
+        </EdgeAnim>
+        <EdgeAnim
+          enter={{ type: 'fadeInUp', distance: 30 }}
+          exit={{ type: 'fadeOutDown' }}
+        >
+          <PasswordStatus passwordEval={passwordEval} />
+        </EdgeAnim>
+
         <EdgeAnim enter={{ type: 'fadeInUp', distance: 25 }}>
           <FilledTextInput
-            horizontal={1.25}
-            bottom={1.25}
+            top={0.75}
+            horizontal={0.75}
+            bottom={0.25}
             value={password}
             secureTextEntry
             returnKeyType="next"
@@ -150,8 +157,8 @@ const ChangePasswordSceneComponent = ({
         </EdgeAnim>
         <EdgeAnim enter={{ type: 'fadeInDown', distance: 25 }}>
           <FilledTextInput
-            horizontal={1.25}
-            bottom={1.25}
+            top={0.25}
+            horizontal={0.75}
             value={confirmPassword}
             secureTextEntry
             returnKeyType="go"
@@ -201,13 +208,9 @@ const ChangePasswordSceneComponent = ({
   return (
     <ThemedScene onBack={onBack} onSkip={onSkip} title={title}>
       {focusSecond ? (
-        <KeyboardAvoidingView
-          style={styles.container}
-          behavior="position"
-          keyboardVerticalOffset={-150}
-        >
+        <KeyboardAwareScrollView style={styles.container}>
           {renderInterior()}
-        </KeyboardAvoidingView>
+        </KeyboardAwareScrollView>
       ) : (
         renderInterior()
       )}
@@ -217,16 +220,14 @@ const ChangePasswordSceneComponent = ({
 
 const getStyles = cacheStyles((theme: Theme) => ({
   container: {
-    flex: 1,
+    flexGrow: 1,
     marginHorizontal: theme.rem(0.5),
-    overflow: 'hidden'
+    marginTop: -theme.rem(0.5)
   },
   description: {
     fontFamily: theme.fontFaceDefault,
     fontSize: theme.rem(0.875),
-    marginBottom: theme.rem(2),
-    marginTop: theme.rem(1),
-    marginHorizontal: theme.rem(0.5)
+    margin: theme.rem(0.5)
   },
   actions: {
     flexDirection: 'row',

--- a/src/components/themed/PasswordStatus.tsx
+++ b/src/components/themed/PasswordStatus.tsx
@@ -6,24 +6,19 @@ import FontAwesome from 'react-native-vector-icons/FontAwesome'
 import SimpleLineIcons from 'react-native-vector-icons/SimpleLineIcons'
 
 import { lstrings } from '../../common/locales/strings'
-import { fixSides, mapSides, sidesToMargin } from '../../util/sides'
 import { EdgeAnim } from '../common/EdgeAnim'
 import { Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from './EdgeText'
 import { IconSignal } from './IconSignal'
 
 interface Props {
-  marginRem?: number[] | number
-  passwordEval?: EdgePasswordRules
+  passwordEval: EdgePasswordRules
 }
 
 export const PasswordStatus = (props: Props) => {
-  const { marginRem, passwordEval } = props
+  const { passwordEval } = props
   const theme = useTheme()
   const styles = getStyles(theme)
-  const spacings = sidesToMargin(mapSides(fixSides(marginRem, 0.5), theme.rem))
-
-  if (passwordEval == null) return null
 
   const { passed, tooShort, noLowerCase, noUpperCase, noNumber } = passwordEval
   const list = [
@@ -42,7 +37,7 @@ export const PasswordStatus = (props: Props) => {
   return (
     <EdgeAnim
       enter={{ type: 'fadeInUp', distance: 100 }}
-      style={[styles.container, passed && styles.passedContainer, spacings]}
+      style={[styles.container, passed && styles.passedContainer]}
     >
       <View style={styles.top}>
         <IconSignal
@@ -76,12 +71,12 @@ export const PasswordStatus = (props: Props) => {
 
 const getStyles = cacheStyles((theme: Theme) => ({
   container: {
-    // HACK: Unable to get this component to cooperate with CardUi4's flex: 1...
-    // Just copying over relevant CardUi4 styles for now
+    // TODO: Sync CardUi4 w/ GUI after finalizing design requirements for this component.
     backgroundColor: theme.cardBaseColor,
     borderRadius: theme.rem(1),
     padding: theme.rem(1),
-    justifyContent: 'flex-start'
+    justifyContent: 'flex-start',
+    margin: theme.rem(0.5)
   },
   top: {
     flexDirection: 'row',
@@ -91,7 +86,7 @@ const getStyles = cacheStyles((theme: Theme) => ({
   message: {
     flexShrink: 1,
     fontFamily: theme.fontFaceBold,
-    marginLeft: theme.rem(1)
+    marginLeft: theme.rem(0.5)
   },
   passwordConditionRow: {
     marginLeft: theme.rem(0.4),


### PR DESCRIPTION
This pull request includes updates to the styling to better follow UI4 conventions and always show the requirements card. 

It also implements a new password validation feature that factors out password requirement checks from the core. 

The changes allow a new requirement row to show up while editing the password confirmation, which will be highlighted in red if the next button is pressed with invalid confirmation input.

<img width="471" alt="image" src="https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/aed363b3-cce3-4a22-be9a-a9b9b880ac9c">
<img width="471" alt="image" src="https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/b11680d9-f06e-49d4-8b7f-9f674126d79d">
<img width="471" alt="image" src="https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/bf6a3a07-192b-4a8a-9c8d-d6429261047b">


### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206517027161207