### PR TITLE
Remove the keyboard type hack for PW entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Unable to highlight password input fields when content is toggled visible
+
 ## 3.6.1 (2024-03-13)
 
 - removed: 'Permission_Modal_Notification_Dismiss' analytics event

--- a/src/components/themed/FilledTextInput.tsx
+++ b/src/components/themed/FilledTextInput.tsx
@@ -281,6 +281,7 @@ export const FilledTextInput = React.forwardRef<
   // text input always blurs immediately after focusing.
   const hackKeyboardType =
     isAndroid &&
+    !secureTextEntry && // Don't apply this hack if we are intentionally doing a secure text entry
     !hidePassword &&
     (keyboardType == null || keyboardType === 'default')
       ? 'visible-password'


### PR DESCRIPTION
The issue does not arise when using
FilledTextInput with secureTextEntry unset on
Android

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206933593008462