### PR TITLE
Refactor password validation and handling in ChangePasswordScene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Ability to set a blank string as the password if using the keyboard next button.
+
 ## 3.7.1 (2024-04-02)
 
 - fixed: Show the `landingScreenText` when provided.


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

Make the scene less "confirmationMatches-specific" and highlight any missed password requirement on form completion. Check ALL password requirements on next, even when bypassing the button with keyboard next.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206963377773537