### PR TITLE
Jon/fix/password-bounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: Always show the password match requirement status
+- fixed: Erratic scrolling during text input focus on ChangePasswordScene
 - fixed: Possible to show multiple modals when rapidly pressing certain buttons
 
 ## 3.11.2 (2024-05-28)

--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -1,6 +1,6 @@
 import { EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
-import { Keyboard } from 'react-native'
+import { Keyboard, Platform } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { cacheStyles } from 'react-native-patina'
 
@@ -114,8 +114,26 @@ const ChangePasswordSceneComponent = ({
       <KeyboardAwareScrollView
         style={styles.container}
         keyboardOpeningTime={0}
+        keyboardShouldPersistTaps="handled"
         enableResetScrollToCoords={false}
-        extraScrollHeight={theme.rem(3.5)}
+        /**
+         * HACK: In iOS:
+         * - extraScrollHeight is ONLY respected when tapping to
+         * focus a field.
+         * - Pressing next does not apply the extraScrollHeight.
+         * - Refuses to respect extraScrollHeight while typing, and
+         * ALWAYS resets the focus position to make the text field sit just
+         * above the keyboard.
+         *
+         * The negative extraScrollHeight at least makes it so that the focus
+         * scroll position doesn't move in iOS, regardless of state.
+         *
+         * Android correctly uses this prop to ensure the "next" button is
+         * always visible above the keyboard, screen size permitting.
+         */
+        extraScrollHeight={
+          Platform.OS === 'ios' ? -theme.rem(1.75) : theme.rem(6)
+        }
         enableAutomaticScroll
         enableOnAndroid
       >

--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -69,7 +69,7 @@ const ChangePasswordSceneComponent = ({
     hasNumber: 'unmet',
     hasLowercase: 'unmet',
     hasUppercase: 'unmet',
-    confirmationMatches: undefined
+    confirmationMatches: 'unmet'
   })
   const [password, setPassword] = React.useState(initPassword ?? '')
   const [confirmPassword, setConfirmPassword] = React.useState('')
@@ -357,9 +357,7 @@ const validatePassword = (
     hasLowercase: /[a-z]/.test(password) ? 'met' : failStatus,
     hasUppercase: /[A-Z]/.test(password) ? 'met' : failStatus,
     confirmationMatches:
-      confirmPassword === ''
-        ? undefined
-        : confirmPassword === password
+      confirmPassword !== '' && confirmPassword === password
         ? 'met'
         : failStatus
   }

--- a/src/components/themed/PasswordStatus.tsx
+++ b/src/components/themed/PasswordStatus.tsx
@@ -24,10 +24,7 @@ export interface PasswordRequirements {
   hasNumber: PasswordRequirementStatus
   hasLowercase: PasswordRequirementStatus
   hasUppercase: PasswordRequirementStatus
-
-  // Initially undefined and omitted from the list until the user starts on the
-  // pw confirmation text field
-  confirmationMatches?: PasswordRequirementStatus
+  confirmationMatches: PasswordRequirementStatus
 }
 
 interface Props {
@@ -57,14 +54,12 @@ export const PasswordStatus = (props: Props) => {
       title: lstrings.must_one_uppercase,
       validationStatus: hasUppercase
     },
-    { title: lstrings.must_one_number, validationStatus: hasNumber }
-  ]
-
-  if (confirmationMatches != null)
-    list.push({
+    { title: lstrings.must_one_number, validationStatus: hasNumber },
+    {
       title: lstrings.password_must_match,
       validationStatus: confirmationMatches
-    })
+    }
+  ]
 
   const passwordValid = !list.some(
     ({ validationStatus }) =>
@@ -121,7 +116,6 @@ export const PasswordStatus = (props: Props) => {
 
 const getStyles = cacheStyles((theme: Theme) => ({
   container: {
-    // TODO: Sync CardUi4 w/ GUI after finalizing design requirements for this component.
     backgroundColor: theme.cardBaseColor,
     borderRadius: theme.rem(1),
     padding: theme.rem(1),


### PR DESCRIPTION
https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/d7cc9182-1a4f-4ffd-878b-1fb41358f032
https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/af96cd46-e481-41fe-8d21-bca53b2bf485

- Passwords must match requirement always shown
- See comments regarding iOS refusing to respect the component props under most situations
- iOS at least no longer bounces on focus/typing, and Android can overscroll to ensure the Next button is visible
- Add keyboardShouldPersistTaps="handled"

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207457101643172