### PR TITLE
Remove iOS negative extraScrollHeight hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Certain iOS device keyboards can cover the 2nd password input field when autofocusing
+
 ## 3.15.0 (2024-06-18)
 
 - changed: showNotificationPermissionReminder returns a value depending on if a prompt was actually shown

--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -1,6 +1,6 @@
 import { EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
-import { Keyboard, Platform } from 'react-native'
+import { Keyboard } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { cacheStyles } from 'react-native-patina'
 
@@ -125,15 +125,10 @@ const ChangePasswordSceneComponent = ({
          * ALWAYS resets the focus position to make the text field sit just
          * above the keyboard.
          *
-         * The negative extraScrollHeight at least makes it so that the focus
-         * scroll position doesn't move in iOS, regardless of state.
-         *
          * Android correctly uses this prop to ensure the "next" button is
          * always visible above the keyboard, screen size permitting.
          */
-        extraScrollHeight={
-          Platform.OS === 'ios' ? -theme.rem(1.75) : theme.rem(6)
-        }
+        extraScrollHeight={theme.rem(6)}
         enableAutomaticScroll
         enableOnAndroid
       >


### PR DESCRIPTION
The hack was originally there just to ensure the scene did not scroll while focusing fields or after the first input keystroke for iOS specifically.

`extraScrollHeight` is still required right now for iOS because the scene does not properly autofocus for some other unknown reason.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207635550315587