### PR TITLE
Disable autofocus in ChangePasswordScene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: Autofocus disabled on ChangePasswordScene
+
 ## 3.15.1 (2024-06-24)
 
 - fixed: Certain iOS device keyboards can cover the 2nd password input field when autofocusing

--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -149,7 +149,6 @@ const ChangePasswordSceneComponent = ({
 
         <EdgeAnim enter={{ type: 'fadeInUp', distance: 25 }}>
           <FilledTextInput
-            autoFocus
             top={0.75}
             horizontal={0.75}
             bottom={0.25}


### PR DESCRIPTION
Temporary fix so at least the input fields AND password requirements are more visible.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207649985934652