### PR TITLE
Jon/smol-4.10

### DIFF
--- a/src/components/common/EdgeAnim.tsx
+++ b/src/components/common/EdgeAnim.tsx
@@ -1,7 +1,11 @@
+/**
+ * IMPORTANT: Changes in this file MUST be synced between edge-react-gui and
+ * edge-login-ui-rn!
+ */
+
 import * as React from 'react'
 import { ViewProps } from 'react-native'
 import Animated, {
-  AnimateProps,
   ComplexAnimationBuilder,
   Easing,
   FadeIn,
@@ -14,13 +18,47 @@ import Animated, {
   FadeOutLeft,
   FadeOutRight,
   FadeOutUp,
-  LinearTransition
+  LinearTransition,
+  StretchInY,
+  StretchOutY
 } from 'react-native-reanimated'
 
-export const DEFAULT_ANIMATION_DURATION_MS = 500
+export const DEFAULT_ANIMATION_DURATION_MS = 300
 export const LAYOUT_ANIMATION = LinearTransition.duration(
   DEFAULT_ANIMATION_DURATION_MS
 )
+export const MAX_LIST_ITEMS_ANIM = 10
+
+// Commonly used enter/exit animations. Use these to prevent
+// dynamically created objects as params that cause a re-render
+export const fadeIn: Anim = { type: 'fadeIn' }
+export const fadeInUp: Anim = { type: 'fadeInUp' }
+export const fadeInUp20: Anim = { type: 'fadeInUp', distance: 20 }
+export const fadeInUp25: Anim = { type: 'fadeInUp', distance: 25 }
+export const fadeInUp30: Anim = { type: 'fadeInUp', distance: 30 }
+export const fadeInUp40: Anim = { type: 'fadeInUp', distance: 40 }
+export const fadeInUp50: Anim = { type: 'fadeInUp', distance: 50 }
+export const fadeInUp60: Anim = { type: 'fadeInUp', distance: 60 }
+export const fadeInUp80: Anim = { type: 'fadeInUp', distance: 80 }
+export const fadeInUp90: Anim = { type: 'fadeInUp', distance: 90 }
+export const fadeInUp110: Anim = { type: 'fadeInUp', distance: 110 }
+export const fadeInUp120: Anim = { type: 'fadeInUp', distance: 120 }
+export const fadeInUp140: Anim = { type: 'fadeInUp', distance: 140 }
+export const fadeInDown: Anim = { type: 'fadeInDown' }
+export const fadeInDown10: Anim = { type: 'fadeInDown', distance: 10 }
+export const fadeInDown20: Anim = { type: 'fadeInDown', distance: 20 }
+export const fadeInDown30: Anim = { type: 'fadeInDown', distance: 30 }
+export const fadeInDown40: Anim = { type: 'fadeInDown', distance: 40 }
+export const fadeInDown50: Anim = { type: 'fadeInDown', distance: 50 }
+export const fadeInDown60: Anim = { type: 'fadeInDown', distance: 60 }
+export const fadeInDown75: Anim = { type: 'fadeInDown', distance: 75 }
+export const fadeInDown80: Anim = { type: 'fadeInDown', distance: 80 }
+export const fadeInDown90: Anim = { type: 'fadeInDown', distance: 90 }
+export const fadeInDown110: Anim = { type: 'fadeInDown', distance: 110 }
+export const fadeInDown120: Anim = { type: 'fadeInDown', distance: 120 }
+export const fadeInDown140: Anim = { type: 'fadeInDown', distance: 140 }
+export const fadeInLeft: Anim = { type: 'fadeInLeft' }
+export const fadeOut: Anim = { type: 'fadeOut' }
 
 type AnimBuilder = typeof ComplexAnimationBuilder
 type AnimTypeFadeIns =
@@ -35,7 +73,13 @@ type AnimTypeFadeOuts =
   | 'fadeOutUp'
   | 'fadeOutLeft'
   | 'fadeOutRight'
-type AnimType = AnimTypeFadeIns | AnimTypeFadeOuts
+type AnimTypeStretchIns = 'stretchInY'
+type AnimTypeStretchOuts = 'stretchOutY'
+type AnimType =
+  | AnimTypeFadeIns
+  | AnimTypeFadeOuts
+  | AnimTypeStretchIns
+  | AnimTypeStretchOuts
 
 interface Anim {
   type: AnimType
@@ -44,9 +88,11 @@ interface Anim {
   distance?: number
 }
 
-interface Props extends AnimateProps<ViewProps> {
+interface Props extends ViewProps {
+  disableAnimation?: boolean
   enter?: Anim
   exit?: Anim
+
   visible?: boolean
 }
 
@@ -60,7 +106,9 @@ const builderMap: Record<AnimType, AnimBuilder> = {
   fadeOutDown: FadeOutDown,
   fadeOutUp: FadeOutUp,
   fadeOutLeft: FadeOutLeft,
-  fadeOutRight: FadeOutRight
+  fadeOutRight: FadeOutRight,
+  stretchInY: StretchInY,
+  stretchOutY: StretchOutY
 }
 
 const getAnimBuilder = (anim?: Anim) => {
@@ -98,16 +146,21 @@ const getAnimBuilder = (anim?: Anim) => {
   return builder
 }
 
-export const EdgeAnim = ({
+const EdgeAnimInner = ({
   children,
+  disableAnimation,
   enter,
   exit,
   visible = true,
   ...rest
-}: Props) => {
+}: Props): JSX.Element | null => {
   if (!visible) return null
   const entering = getAnimBuilder(enter)
   const exiting = getAnimBuilder(exit)
+
+  if (disableAnimation) {
+    return <Animated.View {...rest}>{children}</Animated.View>
+  }
 
   return (
     <Animated.View
@@ -120,3 +173,5 @@ export const EdgeAnim = ({
     </Animated.View>
   )
 }
+
+export const EdgeAnim = React.memo(EdgeAnimInner)

--- a/src/components/common/SceneButtons.tsx
+++ b/src/components/common/SceneButtons.tsx
@@ -1,0 +1,15 @@
+/**
+ * IMPORTANT: Changes in this file MUST be synced between edge-react-gui and
+ * edge-login-ui-rn!
+ */
+
+import * as React from 'react'
+
+import { ButtonsViewUi4, ButtonsViewUi4Props } from '../ui4/ButtonsViewUi4'
+
+interface Props
+  extends Omit<Omit<ButtonsViewUi4Props, 'parentType'>, 'layout'> {}
+
+export const SceneButtons = (props: Props) => {
+  return <ButtonsViewUi4 {...props} parentType="scene" />
+}

--- a/src/components/layout/Space.tsx
+++ b/src/components/layout/Space.tsx
@@ -1,21 +1,162 @@
+/**
+ * IMPORTANT: Changes in this file MUST be synced between edge-react-gui and
+ * edge-login-ui-rn!
+ */
+
 import * as React from 'react'
+import { useMemo } from 'react'
 import { View, ViewStyle } from 'react-native'
 
-import { SpaceProps, useSpaceStyle } from '../../hooks/useSpaceStyle'
+import {
+  MarginRemProps,
+  MarginRemStyle,
+  useMarginRemStyle
+} from '../../hooks/useMarginRemStyle'
 
-interface OwnProps {
+export interface SpaceProps extends MarginRemProps {
+  // Single-sided:
+  /** Align children to the top */
+  alignBottom?: boolean
+  /** Align children to the top */
+  alignLeft?: boolean
+  /** Align children to the right */
+  alignRight?: boolean
+  /** Align children to the top */
+  alignTop?: boolean
+
+  // Multiple-sided:
+  /** Aligns children to the center */
+  alignCenter?: boolean
+  /** Aligns children to the center horizontally */
+  alignHorizontal?: boolean
+  /** Aligns children to the center vertically */
+  alignVertical?: boolean
+
+  // Children:
   children?: React.ReactNode
-  style?: ViewStyle
+
+  /**
+   * The `expand` space prop tells a component to expand its size within its
+   * parent component.
+   *
+   * This is particularly useful when you want to use the space props to
+   * align the component.
+   */
+  expand?: boolean
+
+  /**
+   * Changes the orientation of child component layout from column
+   * (top-to-bottom) to row (left-to-right).
+   *
+   * The `row` prop is an additional, non-space props useful managing the
+   * stacking direction of child components. By default, child components stack
+   * vertically (column-based), from top to bottom. If `row={true}`, then
+   * child components stack horizontally (row-based).
+   *
+   * The `row` prop does not affect the alignment or rem props (i.e. vertical
+   * is always vertical regardless of the value set for the `row` prop).
+   */
+  row?: boolean
 }
-type Props = OwnProps & SpaceProps
 
-/**
- * Numbers are rem units, and boolean means to fill up assigned space; this
- * allows for centering and alignment (see useSpaceStyle hook for details).
- */
-export const Space = React.memo((props: Props) => {
-  const { children, style } = props
-  const spaceStyle = useSpaceStyle(props)
+type SpaceStyle = Pick<
+  ViewStyle,
+  'flex' | 'flexDirection' | 'alignItems' | 'justifyContent'
+> &
+  MarginRemStyle
 
-  return <View style={[spaceStyle, style]}>{children}</View>
+export const Space = React.memo((props: SpaceProps) => {
+  const { children } = props
+  const {
+    aroundRem,
+    horizontalRem,
+    verticalRem,
+    topRem,
+    bottomRem,
+    leftRem,
+    rightRem,
+    expand = false,
+    row = false
+  } = props
+  const {
+    alignBottom,
+    alignLeft,
+    alignRight,
+    alignTop,
+    alignCenter,
+    alignHorizontal,
+    alignVertical
+  } = props
+
+  const topFill = boolify(alignBottom, alignVertical, alignCenter)
+  const bottomFill = boolify(alignTop, alignVertical, alignCenter)
+  const leftFill = boolify(alignRight, alignHorizontal, alignCenter)
+  const rightFill = boolify(alignLeft, alignHorizontal, alignCenter)
+
+  // Margins:
+  const marginRemStyle = useMarginRemStyle({
+    bottomRem,
+    leftRem,
+    rightRem,
+    topRem,
+    aroundRem,
+    horizontalRem,
+    verticalRem
+  })
+
+  // Direction:
+  const flexDirection = row ? 'row' : 'column'
+
+  // Alignment:
+  const horizontalAlignment =
+    leftFill && rightFill
+      ? 'center'
+      : rightFill
+      ? 'flex-start'
+      : leftFill
+      ? 'flex-end'
+      : undefined
+  const verticalAlignment =
+    topFill && bottomFill
+      ? 'center'
+      : bottomFill
+      ? 'flex-start'
+      : topFill
+      ? 'flex-end'
+      : undefined
+  const alignItems = row ? verticalAlignment : horizontalAlignment
+  const justifyContent = row
+    ? horizontalAlignment ?? (expand ? 'space-between' : undefined)
+    : verticalAlignment
+
+  // Flex:
+  const alignSelf = expand ? 'stretch' : undefined
+  const flexGrow = expand ? 1 : undefined
+
+  const spaceStyle: SpaceStyle = useMemo(
+    () => ({
+      alignSelf,
+      alignItems,
+      flexGrow,
+      flexDirection,
+      justifyContent,
+      ...marginRemStyle
+    }),
+    [
+      alignItems,
+      alignSelf,
+      flexDirection,
+      flexGrow,
+      justifyContent,
+      marginRemStyle
+    ]
+  )
+
+  return <View style={spaceStyle}>{children}</View>
 })
+
+const boolify = (...things: Array<boolean | undefined>): boolean => {
+  return things.some(thing => {
+    return typeof thing === 'boolean' && thing
+  })
+}

--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -10,13 +10,13 @@ import { useImports } from '../../hooks/useImports'
 import { useDispatch } from '../../types/ReduxTypes'
 import { SceneProps } from '../../types/routerTypes'
 import { EdgeAnim } from '../common/EdgeAnim'
+import { SceneButtons } from '../common/SceneButtons'
 import { WarningCard } from '../common/WarningCard'
 import { ButtonsModal } from '../modals/ButtonsModal'
 import { Airship, showError } from '../services/AirshipInstance'
 import { Theme, useTheme } from '../services/ThemeContext'
 import { EdgeText } from '../themed/EdgeText'
 import { FilledTextInput, FilledTextInputRef } from '../themed/FilledTextInput'
-import { MainButton } from '../themed/MainButton'
 import {
   PasswordRequirements,
   PasswordRequirementStatus,
@@ -63,7 +63,6 @@ const ChangePasswordSceneComponent = ({
 }: Props) => {
   const theme = useTheme()
   const styles = getStyles(theme)
-  const [spinning, setSpinning] = React.useState(false)
   const [passwordReqs, setPasswordReqs] = React.useState<PasswordRequirements>({
     minLengthMet: 'unmet',
     hasNumber: 'unmet',
@@ -82,8 +81,6 @@ const ChangePasswordSceneComponent = ({
     .some(([, value]) => value === 'unmet' || value === 'error')
 
   const handleNext = useHandler(async () => {
-    setSpinning(true)
-
     const newPasswordReqs = validatePassword(password, confirmPassword, 'error')
     setPasswordReqs(newPasswordReqs)
     if (
@@ -97,8 +94,6 @@ const ChangePasswordSceneComponent = ({
         showError(e)
       }
     }
-
-    setSpinning(false)
   })
 
   const handleSubmitPasswordField = useHandler(() => {
@@ -177,23 +172,14 @@ const ChangePasswordSceneComponent = ({
             maxLength={100}
           />
         </EdgeAnim>
-        <EdgeAnim
-          style={styles.actions}
-          enter={{ type: 'fadeInDown', distance: 50 }}
-          exit={{ type: 'fadeOutDown', distance: 50 }}
-        >
-          {spinning ? (
-            <MainButton disabled marginRem={0.5} type="primary" spinner />
-          ) : (
-            <MainButton
-              label={mainButtonLabel}
-              disabled={isNextButtonDisabled || confirmPassword === ''}
-              marginRem={0.5}
-              onPress={handleNext}
-              type="primary"
-            />
-          )}
-        </EdgeAnim>
+        <SceneButtons
+          primary={{
+            label: mainButtonLabel,
+            disabled: isNextButtonDisabled || confirmPassword === '',
+            onPress: handleNext
+          }}
+          animDistanceStart={50}
+        />
       </KeyboardAwareScrollView>
     </ThemedScene>
   )

--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -72,6 +72,7 @@ const ChangePasswordSceneComponent = ({
   })
   const [password, setPassword] = React.useState(initPassword ?? '')
   const [confirmPassword, setConfirmPassword] = React.useState('')
+  const [spinner, setSpinner] = React.useState(false)
 
   const secondInputRef = React.useRef<FilledTextInputRef>(null)
 
@@ -88,11 +89,13 @@ const ChangePasswordSceneComponent = ({
         ([, value]) => value === 'unmet' || value === 'error'
       )
     ) {
+      setSpinner(true)
       try {
         await onSubmit(password)
       } catch (e) {
         showError(e)
       }
+      setSpinner(false)
     }
   })
 
@@ -107,7 +110,7 @@ const ChangePasswordSceneComponent = ({
   return (
     <ThemedScene onBack={onBack} onSkip={onSkip} title={title}>
       <KeyboardAwareScrollView
-        style={styles.container}
+        contentContainerStyle={styles.container}
         keyboardOpeningTime={0}
         keyboardShouldPersistTaps="handled"
         enableResetScrollToCoords={false}
@@ -172,15 +175,17 @@ const ChangePasswordSceneComponent = ({
             maxLength={100}
           />
         </EdgeAnim>
-        <SceneButtons
-          primary={{
-            label: mainButtonLabel,
-            disabled: isNextButtonDisabled || confirmPassword === '',
-            onPress: handleNext
-          }}
-          animDistanceStart={50}
-        />
       </KeyboardAwareScrollView>
+      <SceneButtons
+        absolute
+        primary={{
+          label: mainButtonLabel,
+          disabled: isNextButtonDisabled || confirmPassword === '',
+          onPress: handleNext,
+          spinner
+        }}
+        animDistanceStart={50}
+      />
     </ThemedScene>
   )
 }
@@ -189,12 +194,11 @@ const getStyles = cacheStyles((theme: Theme) => ({
   container: {
     flexGrow: 1,
     marginHorizontal: theme.rem(0.5),
-    marginTop: -theme.rem(0.5)
+    alignContent: 'flex-start'
   },
   description: {
-    fontFamily: theme.fontFaceDefault,
     fontSize: theme.rem(0.875),
-    margin: theme.rem(0.5)
+    marginBottom: theme.rem(0.5)
   },
   actions: {
     flexDirection: 'row',

--- a/src/components/scenes/ChangePinScene.tsx
+++ b/src/components/scenes/ChangePinScene.tsx
@@ -66,6 +66,9 @@ const ChangePinSceneComponent = ({
     // Change pin only when input are numbers
     if ((/^\d+$/.test(newPin) || newPin.length === 0) && newPin.length <= 4) {
       setPin(newPin)
+      if (newPin.length === 4) {
+        Keyboard.dismiss()
+      }
     }
   })
 
@@ -75,7 +78,7 @@ const ChangePinSceneComponent = ({
     <ThemedScene onBack={onBack} onSkip={onSkip} title={title}>
       <ScrollView
         ref={scrollViewRef}
-        style={styles.content}
+        contentContainerStyle={styles.content}
         keyboardShouldPersistTaps="handled"
       >
         <EdgeAnim enter={{ type: 'fadeInUp' }}>
@@ -90,15 +93,16 @@ const ChangePinSceneComponent = ({
             onChangePin={handleChangePin}
           />
         </EdgeAnim>
-        <SceneButtons
-          primary={{
-            label: mainButtonLabel,
-            onPress: handlePress,
-            disabled: !isValidPin
-          }}
-          animDistanceStart={1}
-        />
       </ScrollView>
+      <SceneButtons
+        absolute
+        primary={{
+          label: mainButtonLabel,
+          onPress: handlePress,
+          disabled: !isValidPin
+        }}
+        animDistanceStart={50}
+      />
     </ThemedScene>
   )
 }
@@ -106,11 +110,9 @@ const ChangePinSceneComponent = ({
 const getStyles = cacheStyles((theme: Theme) => ({
   content: {
     flexGrow: 1,
-    marginHorizontal: theme.rem(0.5),
-    marginTop: theme.rem(1)
+    marginHorizontal: theme.rem(0.5)
   },
   description: {
-    fontFamily: theme.fontFaceDefault,
     fontSize: theme.rem(0.875),
     marginBottom: theme.rem(2)
   }

--- a/src/components/scenes/ChangePinScene.tsx
+++ b/src/components/scenes/ChangePinScene.tsx
@@ -13,12 +13,12 @@ import { useScrollToEnd } from '../../hooks/useScrollToEnd'
 import { useDispatch } from '../../types/ReduxTypes'
 import { SceneProps } from '../../types/routerTypes'
 import { EdgeAnim } from '../common/EdgeAnim'
+import { SceneButtons } from '../common/SceneButtons'
 import { ButtonsModal } from '../modals/ButtonsModal'
 import { Airship, showError } from '../services/AirshipInstance'
 import { Theme, useTheme } from '../services/ThemeContext'
 import { DigitInput, MAX_PIN_LENGTH } from '../themed/DigitInput'
 import { EdgeText } from '../themed/EdgeText'
-import { MainButton } from '../themed/MainButton'
 import { ThemedScene } from '../themed/ThemedScene'
 
 export interface ChangePinParams {
@@ -90,18 +90,14 @@ const ChangePinSceneComponent = ({
             onChangePin={handleChangePin}
           />
         </EdgeAnim>
-        <EdgeAnim
-          style={styles.actions}
-          visible={isValidPin}
-          enter={{ type: 'fadeInDown' }}
-          exit={{ type: 'fadeOutDown' }}
-        >
-          <MainButton
-            label={mainButtonLabel}
-            type="primary"
-            onPress={handlePress}
-          />
-        </EdgeAnim>
+        <SceneButtons
+          primary={{
+            label: mainButtonLabel,
+            onPress: handlePress,
+            disabled: !isValidPin
+          }}
+          animDistanceStart={1}
+        />
       </ScrollView>
     </ThemedScene>
   )
@@ -109,7 +105,7 @@ const ChangePinSceneComponent = ({
 
 const getStyles = cacheStyles((theme: Theme) => ({
   content: {
-    flex: 1,
+    flexGrow: 1,
     marginHorizontal: theme.rem(0.5),
     marginTop: theme.rem(1)
   },
@@ -117,11 +113,6 @@ const getStyles = cacheStyles((theme: Theme) => ({
     fontFamily: theme.fontFaceDefault,
     fontSize: theme.rem(0.875),
     marginBottom: theme.rem(2)
-  },
-  actions: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    marginTop: theme.rem(2)
   }
 }))
 

--- a/src/components/scenes/newAccount/NewAccountReviewScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountReviewScene.tsx
@@ -10,11 +10,11 @@ import { useImports } from '../../../hooks/useImports'
 import { useDispatch } from '../../../types/ReduxTypes'
 import { SceneProps } from '../../../types/routerTypes'
 import { EdgeAnim } from '../../common/EdgeAnim'
+import { SceneButtons } from '../../common/SceneButtons'
 import { Theme, useTheme } from '../../services/ThemeContext'
 import { AccountInfo } from '../../themed/AccountInfo'
 import { EdgeText } from '../../themed/EdgeText'
 import { FormError } from '../../themed/FormError'
-import { MainButton } from '../../themed/MainButton'
 import { ThemedScene } from '../../themed/ThemedScene'
 
 export interface NewAccountReviewParams {
@@ -67,13 +67,12 @@ const AccountReviewComponent = (props: Props) => {
             pin={pin}
           />
         </EdgeAnim>
-        <EdgeAnim
-          style={styles.actions}
-          enter={{ type: 'fadeInDown', distance: 60 }}
-        >
-          <MainButton label={lstrings.create} type="primary" onPress={onNext} />
-        </EdgeAnim>
       </ScrollView>
+      <SceneButtons
+        absolute
+        primary={{ label: lstrings.create, onPress: onNext }}
+        animDistanceStart={60}
+      />
     </ThemedScene>
   )
 }
@@ -87,12 +86,6 @@ const getStyles = cacheStyles((theme: Theme) => ({
     fontFamily: theme.fontFaceDefault,
     fontSize: theme.rem(0.875),
     marginBottom: theme.rem(2)
-  },
-  actions: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    marginTop: theme.rem(5),
-    minHeight: theme.rem(3)
   }
 }))
 

--- a/src/components/scenes/newAccount/NewAccountReviewScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountReviewScene.tsx
@@ -71,7 +71,7 @@ const AccountReviewComponent = (props: Props) => {
       <SceneButtons
         absolute
         primary={{ label: lstrings.create, onPress: onNext }}
-        animDistanceStart={60}
+        animDistanceStart={50}
       />
     </ThemedScene>
   )
@@ -79,11 +79,9 @@ const AccountReviewComponent = (props: Props) => {
 
 const getStyles = cacheStyles((theme: Theme) => ({
   content: {
-    marginHorizontal: theme.rem(0.5),
-    marginTop: theme.rem(1.5)
+    marginHorizontal: theme.rem(0.5)
   },
   description: {
-    fontFamily: theme.fontFaceDefault,
     fontSize: theme.rem(0.875),
     marginBottom: theme.rem(2)
   }

--- a/src/components/scenes/newAccount/NewAccountTosScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountTosScene.tsx
@@ -108,19 +108,20 @@ const TosComponent = (props: Props) => {
             </EdgeText>
           </EdgeText>
         </EdgeAnim>
-        <EdgeAnim
-          enter={{ type: 'fadeInDown' }}
-          exit={{ type: 'fadeOutDown' }}
-          visible={showNext}
-        >
-          <SceneButtons
-            primary={{
-              label: lstrings.confirm,
-              onPress: onNext
-            }}
-          />
-        </EdgeAnim>
       </ScrollView>
+      <EdgeAnim
+        enter={{ type: 'fadeInDown' }}
+        exit={{ type: 'fadeOutDown' }}
+        visible={showNext}
+      >
+        <SceneButtons
+          absolute
+          primary={{
+            label: lstrings.confirm,
+            onPress: onNext
+          }}
+        />
+      </EdgeAnim>
     </ThemedScene>
   )
 }

--- a/src/components/scenes/newAccount/NewAccountTosScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountTosScene.tsx
@@ -14,13 +14,13 @@ import { Branding } from '../../../types/Branding'
 import { useDispatch } from '../../../types/ReduxTypes'
 import { SceneProps } from '../../../types/routerTypes'
 import { EdgeAnim } from '../../common/EdgeAnim'
+import { SceneButtons } from '../../common/SceneButtons'
 import { ChallengeModal } from '../../modals/ChallengeModal'
 import { Airship, showError } from '../../services/AirshipInstance'
 import { Theme, useTheme } from '../../services/ThemeContext'
 import { Checkbox } from '../../themed/Checkbox'
 import { EdgeText } from '../../themed/EdgeText'
 import { ThemedScene } from '../../themed/ThemedScene'
-import { ButtonsViewUi4 } from '../../ui4/ButtonsViewUi4'
 
 export interface UpgradeTosParams {
   account: EdgeAccount
@@ -113,12 +113,11 @@ const TosComponent = (props: Props) => {
           exit={{ type: 'fadeOutDown' }}
           visible={showNext}
         >
-          <ButtonsViewUi4
+          <SceneButtons
             primary={{
               label: lstrings.confirm,
               onPress: onNext
             }}
-            parentType="scene"
           />
         </EdgeAnim>
       </ScrollView>

--- a/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
@@ -13,10 +13,10 @@ import { Branding } from '../../../types/Branding'
 import { useDispatch } from '../../../types/ReduxTypes'
 import { SceneProps } from '../../../types/routerTypes'
 import { EdgeAnim } from '../../common/EdgeAnim'
+import { SceneButtons } from '../../common/SceneButtons'
 import { Theme, useTheme } from '../../services/ThemeContext'
 import { EdgeText } from '../../themed/EdgeText'
 import { FilledTextInput } from '../../themed/FilledTextInput'
-import { MainButton } from '../../themed/MainButton'
 import { ThemedScene } from '../../themed/ThemedScene'
 
 export interface NewAccountUsernameParams {
@@ -184,15 +184,14 @@ export const ChangeUsernameComponent = (props: Props) => {
               valid={availableText}
             />
           </EdgeAnim>
-          <EdgeAnim enter={{ type: 'fadeInDown', distance: 50 }}>
-            <MainButton
-              label={lstrings.next_label}
-              type="primary"
-              marginRem={[0.5, 0]}
-              disabled={isNextDisabled}
-              onPress={handleNext}
-            />
-          </EdgeAnim>
+          <SceneButtons
+            primary={{
+              label: lstrings.next_label,
+              onPress: handleNext,
+              disabled: isNextDisabled
+            }}
+            animDistanceStart={50}
+          />
         </KeyboardAwareScrollView>
       </View>
     </ThemedScene>

--- a/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
@@ -1,6 +1,5 @@
 import { EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
-import { View } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { cacheStyles } from 'react-native-patina'
 import { sprintf } from 'sprintf-js'
@@ -154,46 +153,45 @@ export const ChangeUsernameComponent = (props: Props) => {
 
   return (
     <ThemedScene onBack={handleBack} title={lstrings.choose_title_username}>
-      <View style={styles.content}>
-        <KeyboardAwareScrollView
-          contentContainerStyle={styles.mainScrollView}
-          keyboardShouldPersistTaps="handled"
-        >
-          <EdgeAnim enter={{ type: 'fadeInUp', distance: 50 }}>
-            <EdgeText style={styles.description} numberOfLines={2}>
-              {sprintf(
-                lstrings.username_desc,
-                branding.appName || lstrings.app_name_default
-              )}
-            </EdgeText>
-          </EdgeAnim>
-          <EdgeAnim enter={{ type: 'fadeInDown', distance: 25 }}>
-            <FilledTextInput
-              around={1}
-              autoCapitalize="none"
-              autoCorrect={false}
-              autoFocus
-              placeholder={lstrings.username}
-              onChangeText={handleChangeText}
-              onSubmitEditing={handleNext}
-              returnKeyType="go"
-              value={username ?? ''}
-              clearIcon={!isFetchingAvailability}
-              showSpinner={isFetchingAvailability}
-              error={errorText}
-              valid={availableText}
-            />
-          </EdgeAnim>
-          <SceneButtons
-            primary={{
-              label: lstrings.next_label,
-              onPress: handleNext,
-              disabled: isNextDisabled
-            }}
-            animDistanceStart={50}
+      <KeyboardAwareScrollView
+        contentContainerStyle={styles.mainScrollView}
+        keyboardShouldPersistTaps="handled"
+      >
+        <EdgeAnim enter={{ type: 'fadeInUp', distance: 50 }}>
+          <EdgeText style={styles.description} numberOfLines={2}>
+            {sprintf(
+              lstrings.username_desc,
+              branding.appName || lstrings.app_name_default
+            )}
+          </EdgeText>
+        </EdgeAnim>
+        <EdgeAnim enter={{ type: 'fadeInDown', distance: 25 }}>
+          <FilledTextInput
+            around={1}
+            autoCapitalize="none"
+            autoCorrect={false}
+            autoFocus
+            placeholder={lstrings.username}
+            onChangeText={handleChangeText}
+            onSubmitEditing={handleNext}
+            returnKeyType="go"
+            value={username ?? ''}
+            clearIcon={!isFetchingAvailability}
+            showSpinner={isFetchingAvailability}
+            error={errorText}
+            valid={availableText}
           />
-        </KeyboardAwareScrollView>
-      </View>
+        </EdgeAnim>
+      </KeyboardAwareScrollView>
+      <SceneButtons
+        absolute
+        primary={{
+          label: lstrings.next_label,
+          onPress: handleNext,
+          disabled: isNextDisabled
+        }}
+        animDistanceStart={50}
+      />
     </ThemedScene>
   )
 }
@@ -213,17 +211,12 @@ const getUsernameFormatError = (text: string): null | string => {
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({
-  content: {
-    flex: 1,
-    marginHorizontal: theme.rem(0.5),
-    marginTop: theme.rem(1.5)
-  },
   mainScrollView: {
-    flex: 1,
-    alignContent: 'flex-start'
+    flexGrow: 1,
+    alignContent: 'flex-start',
+    marginHorizontal: theme.rem(0.5)
   },
   description: {
-    fontFamily: theme.fontFaceDefault,
     fontSize: theme.rem(0.875),
     marginBottom: theme.rem(1)
   }

--- a/src/hooks/useMarginRemStyle.ts
+++ b/src/hooks/useMarginRemStyle.ts
@@ -1,0 +1,70 @@
+/**
+ * IMPORTANT: Changes in this file MUST be synced between edge-react-gui and
+ * edge-login-ui-rn!
+ */
+
+import { useMemo } from 'react'
+import { ViewStyle } from 'react-native'
+
+import { useTheme } from '../components/services/ThemeContext'
+
+export interface MarginRemProps {
+  // Single-sided:
+  /** Adds rem to the bottom margin side */
+  bottomRem?: number
+  /** Adds rem to the left margin side */
+  leftRem?: number
+  /** Adds rem to the right margin side */
+  rightRem?: number
+  /** Adds rem to the top margin side */
+  topRem?: number
+
+  // Multiple-sided:
+  /** Adds rem to all margin sides */
+  aroundRem?: number
+  /** Adds rem to left and right margin sides */
+  horizontalRem?: number
+  /** Adds rem to top and bottom margin sides */
+  verticalRem?: number
+}
+
+export type MarginRemStyle = Pick<
+  ViewStyle,
+  'marginTop' | 'marginBottom' | 'marginLeft' | 'marginRight'
+>
+
+export const useMarginRemStyle = (props: MarginRemProps): MarginRemStyle => {
+  const theme = useTheme()
+  const {
+    aroundRem,
+    horizontalRem,
+    verticalRem,
+    topRem,
+    bottomRem,
+    leftRem,
+    rightRem
+  } = props
+
+  const topUnits = topRem ?? verticalRem ?? aroundRem ?? 0
+  const bottomUnits = bottomRem ?? verticalRem ?? aroundRem ?? 0
+  const leftUnits = leftRem ?? horizontalRem ?? aroundRem ?? 0
+  const rightUnits = rightRem ?? horizontalRem ?? aroundRem ?? 0
+
+  // Margins:
+  const marginTop = theme.rem(topUnits)
+  const marginBottom = theme.rem(bottomUnits)
+  const marginLeft = theme.rem(leftUnits)
+  const marginRight = theme.rem(rightUnits)
+
+  const style: MarginRemStyle = useMemo(
+    () => ({
+      marginTop,
+      marginBottom,
+      marginLeft,
+      marginRight
+    }),
+    [marginBottom, marginLeft, marginRight, marginTop]
+  )
+
+  return style
+}


### PR DESCRIPTION
Before 

![image](https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/531696f0-360a-4faf-903c-f056744ede57)

After 

![image](https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/9fbbf25a-21b6-4a2f-87de-a8c051184d04)

Before 

![image](https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/975e97cb-64c3-41cf-9287-eafb24c58a21)

After 

![image](https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/49c62625-16c3-491d-9fd2-55be34f15ce5)<img width="391" alt="Screenshot 2024-07-05 at 3 10 41 PM" src="https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/d0347049-d916-4044-b8fa-09d8aeb3fd1a">
<img width="391" alt="Screenshot 2024-07-05 at 3 10 26 PM" src="https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/190c74bc-fc53-452b-969d-4aaa44a8fc0a">

Before 

![image](https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/d21c7278-2593-4410-ae16-59d86013c523)

After 

![image](https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/cc8421bf-ba25-4b63-9303-ed6a2df71b3d)
<img width="395" alt="image" src="https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/46dec8f5-b59e-42a3-ae95-774c6918c1d2">


Before 

<img width="394" alt="image" src="https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/1ac4bbb9-3e41-4fd0-ae88-0cdeb21873f5">

After 

<img width="396" alt="image" src="https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/5579d1af-da10-40b3-8444-4dc717481c9c">

Before 

![image](https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/f846a0f5-e9d2-4dd6-b731-684325b6123e)

After 

![image](https://github.com/EdgeApp/edge-login-ui-rn/assets/90650827/6e093dca-617a-4e72-b587-58182a1f31ed)



- Sync ButtonsView and related with GUI
- Use SceneButtons for account creation scenes
- Adjust styling:
- Remove some nested views
- Make the description texts consistent in spacing, at least against the scene headers
- Make all buttons consistently pinned to the bottom of the scenes. We can't guarantee they're always visible on all devices above the keyboard, anyway, so just make them consistent.


### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207484709639297