### PR TITLE
Add keyboard padding to scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: Next button on ChangeUsername and ChangePassword scenes dynamically remain above keyboard, while also being scrollable into view while the keyboard is open
+
 ## 3.16.3 (2024-07-19)
 
 - fixed: Use consistent styling throughout the account creation flow

--- a/src/components/scenes/ChangePasswordScene.tsx
+++ b/src/components/scenes/ChangePasswordScene.tsx
@@ -7,6 +7,7 @@ import { cacheStyles } from 'react-native-patina'
 import { lstrings } from '../../common/locales/strings'
 import { useHandler } from '../../hooks/useHandler'
 import { useImports } from '../../hooks/useImports'
+import { useKeyboardPadding } from '../../hooks/useKeyboardPadding'
 import { useDispatch } from '../../types/ReduxTypes'
 import { SceneProps } from '../../types/routerTypes'
 import { EdgeAnim } from '../common/EdgeAnim'
@@ -63,6 +64,8 @@ const ChangePasswordSceneComponent = ({
 }: Props) => {
   const theme = useTheme()
   const styles = getStyles(theme)
+  const keyboardPadding = useKeyboardPadding()
+
   const [passwordReqs, setPasswordReqs] = React.useState<PasswordRequirements>({
     minLengthMet: 'unmet',
     hasNumber: 'unmet',
@@ -110,7 +113,7 @@ const ChangePasswordSceneComponent = ({
   return (
     <ThemedScene onBack={onBack} onSkip={onSkip} title={title}>
       <KeyboardAwareScrollView
-        contentContainerStyle={styles.container}
+        contentContainerStyle={[styles.container, keyboardPadding]}
         keyboardOpeningTime={0}
         keyboardShouldPersistTaps="handled"
         enableResetScrollToCoords={false}
@@ -175,17 +178,16 @@ const ChangePasswordSceneComponent = ({
             maxLength={100}
           />
         </EdgeAnim>
+        <SceneButtons
+          primary={{
+            label: mainButtonLabel,
+            disabled: isNextButtonDisabled || confirmPassword === '',
+            onPress: handleNext,
+            spinner
+          }}
+          animDistanceStart={50}
+        />
       </KeyboardAwareScrollView>
-      <SceneButtons
-        absolute
-        primary={{
-          label: mainButtonLabel,
-          disabled: isNextButtonDisabled || confirmPassword === '',
-          onPress: handleNext,
-          spinner
-        }}
-        animDistanceStart={50}
-      />
     </ThemedScene>
   )
 }

--- a/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
@@ -8,6 +8,7 @@ import { maybeRouteComplete } from '../../../actions/LoginInitActions'
 import { lstrings } from '../../../common/locales/strings'
 import { useHandler } from '../../../hooks/useHandler'
 import { useImports } from '../../../hooks/useImports'
+import { useKeyboardPadding } from '../../../hooks/useKeyboardPadding'
 import { Branding } from '../../../types/Branding'
 import { useDispatch } from '../../../types/ReduxTypes'
 import { SceneProps } from '../../../types/routerTypes'
@@ -47,6 +48,7 @@ export const ChangeUsernameComponent = (props: Props) => {
   const imports = useImports()
   const theme = useTheme()
   const styles = getStyles(theme)
+  const keyboardPadding = useKeyboardPadding()
 
   const [username, setUsername] = React.useState(initUsername ?? '')
   const [timerId, setTimerId] = React.useState<Timeout | undefined>(undefined)
@@ -154,7 +156,7 @@ export const ChangeUsernameComponent = (props: Props) => {
   return (
     <ThemedScene onBack={handleBack} title={lstrings.choose_title_username}>
       <KeyboardAwareScrollView
-        contentContainerStyle={styles.mainScrollView}
+        contentContainerStyle={[styles.mainScrollView, keyboardPadding]}
         keyboardShouldPersistTaps="handled"
       >
         <EdgeAnim enter={{ type: 'fadeInUp', distance: 50 }}>
@@ -182,16 +184,15 @@ export const ChangeUsernameComponent = (props: Props) => {
             valid={availableText}
           />
         </EdgeAnim>
+        <SceneButtons
+          primary={{
+            label: lstrings.next_label,
+            onPress: handleNext,
+            disabled: isNextDisabled
+          }}
+          animDistanceStart={50}
+        />
       </KeyboardAwareScrollView>
-      <SceneButtons
-        absolute
-        primary={{
-          label: lstrings.next_label,
-          onPress: handleNext,
-          disabled: isNextDisabled
-        }}
-        animDistanceStart={50}
-      />
     </ThemedScene>
   )
 }
@@ -211,6 +212,9 @@ const getUsernameFormatError = (text: string): null | string => {
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({
+  keyboardAvoidingView: {
+    flex: 1
+  },
   mainScrollView: {
     flexGrow: 1,
     alignContent: 'flex-start',

--- a/src/hooks/useKeyboardPadding.ts
+++ b/src/hooks/useKeyboardPadding.ts
@@ -1,0 +1,41 @@
+import React, { SetStateAction } from 'react'
+import { Keyboard } from 'react-native'
+
+export const useKeyboardPadding = () => {
+  const [keyboardHeight, setKeyboardHeight] = React.useState(0)
+
+  React.useEffect(() => {
+    const keyboardDidShow = (event: {
+      endCoordinates: { height: SetStateAction<number> }
+    }) => {
+      setKeyboardHeight(event.endCoordinates.height)
+    }
+    const keyboardDidHide = () => {
+      setKeyboardHeight(0)
+    }
+
+    const showSubscription = Keyboard.addListener(
+      'keyboardDidShow',
+      keyboardDidShow
+    )
+    const hideSubscription = Keyboard.addListener(
+      'keyboardDidHide',
+      keyboardDidHide
+    )
+
+    // Cleanup function to remove the event listeners
+    return () => {
+      showSubscription.remove()
+      hideSubscription.remove()
+    }
+  }, [])
+
+  const style = React.useMemo(
+    () => ({
+      paddingBottom: keyboardHeight
+    }),
+    [keyboardHeight]
+  )
+
+  return style
+}


### PR DESCRIPTION
The PIN scene doesn't need it because the keyboard already auto-drops when the requirements are met, and there's no way to progress otherwise.

Could have changed the keyboard UX on the PIN scene, but there's talks of revamping the create account flow, anyway.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207895858615653