### PR TITLE
Handle wait on the password login scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: When password login is locked out for some time period, show the time instead of "Invalid password".
+
 ## 3.18.0 (2024-08-22)
 
 - changed: "<No Username>" changed to: "Guest Account ([last 3 loginId characters])"

--- a/src/common/locales/strings/enUS.json
+++ b/src/common/locales/strings/enUS.json
@@ -138,6 +138,7 @@
   "password_recovery": "Password Recovery",
   "password_requirements": "Password Requirements",
   "password": "Password",
+  "password_wait_1s": "Please try again in %1$s",
   "pin_changed": "PIN Changed",
   "pin_desc_alt": "Your PIN is a 4 digit code used to quickly log back into your account.",
   "pin_desc": "Your PIN is a 4 digit code used to quickly log back into your account.\n\nPIN login is only usable on a device after first login with password.",

--- a/src/components/scenes/PasswordLoginScene.tsx
+++ b/src/components/scenes/PasswordLoginScene.tsx
@@ -29,6 +29,7 @@ import { lstrings } from '../../common/locales/strings'
 import { useHandler } from '../../hooks/useHandler'
 import { useImports } from '../../hooks/useImports'
 import { LoginUserInfo, useLocalUsers } from '../../hooks/useLocalUsers'
+import { formatWait } from '../../locales/intl'
 import { Branding } from '../../types/Branding'
 import { useDispatch } from '../../types/ReduxTypes'
 import { SceneProps } from '../../types/routerTypes'
@@ -232,7 +233,14 @@ export const PasswordLoginScene = (props: Props) => {
 
       const passwordError = asMaybePasswordError(error)
       if (passwordError != null) {
-        setPasswordErrorMessage(lstrings.invalid_password)
+        const { wait } = passwordError
+        if (wait != null) {
+          setPasswordErrorMessage(
+            sprintf(lstrings.password_wait_1s, formatWait(wait))
+          )
+        } else {
+          setPasswordErrorMessage(lstrings.invalid_password)
+        }
         return
       }
 

--- a/src/locales/intl.ts
+++ b/src/locales/intl.ts
@@ -265,6 +265,16 @@ export function formatTime(date: Date): string {
 }
 
 /**
+ * Formats a time duration, such as 1.5 minutes or 2 hours
+ */
+export function formatWait(seconds: number): string {
+  if (seconds > 90 * 60) return (seconds / (60 * 60)).toFixed(1) + 'h'
+  if (seconds > 90) return (seconds / 60).toFixed(1) + 'm'
+  if (seconds > 1) return seconds.toFixed(1) + 's'
+  return (1000 * seconds).toFixed(1) + 'ms'
+}
+
+/**
  * Returns 'h:mm am/pm, date' string depending on locale.
  */
 export function formatTimeDate(date: Date, dateFormat?: string): string {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

This is a very bad PR. Ideally, we should be handling the wait with a countdown timer like we do on the PIN scene.

The current UI is leading users astray, so we want to get it fixed ASAP. We can maybe do a follow-up task to make this better.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208115758182862