### PR TITLE
Fix `NewAccountTosScene` confirm button styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: `NewAccountTosScene` confirm button obscures text on some devices
+
 ## 3.22.4 (2024-10-01)
 
 - changed: Update translations

--- a/src/components/scenes/newAccount/NewAccountTosScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountTosScene.tsx
@@ -93,7 +93,11 @@ const TosComponent = (props: Props) => {
             </Checkbox>
           </EdgeAnim>
         ))}
-        <EdgeAnim enter={{ type: 'fadeInDown' }}>
+        <EdgeAnim
+          enter={{ type: 'fadeInDown' }}
+          exit={{ type: 'fadeOutDown' }}
+          visible={showNext}
+        >
           <EdgeText
             style={styles.agreeText}
             numberOfLines={2}
@@ -106,21 +110,15 @@ const TosComponent = (props: Props) => {
               {lstrings.read_understood_2}
             </EdgeText>
           </EdgeText>
+
+          <SceneButtons
+            primary={{
+              label: lstrings.confirm,
+              onPress: onNext
+            }}
+          />
         </EdgeAnim>
       </ScrollView>
-      <EdgeAnim
-        enter={{ type: 'fadeInDown' }}
-        exit={{ type: 'fadeOutDown' }}
-        visible={showNext}
-      >
-        <SceneButtons
-          absolute
-          primary={{
-            label: lstrings.confirm,
-            onPress: onNext
-          }}
-        />
-      </EdgeAnim>
     </ThemedScene>
   )
 }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/d5a01b3c-848f-430d-8692-63d416b98e4c)


Also include the last block of text in the show/hide animation, because that's what the confirm button is actually confirming.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208557920389984