### PR TITLE
Fix recovery date off by one day bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Fix recovery date off by one day bug.
+
 ## 3.24.2 (2025-01-06)
 
 - fixed: `SecurityAlertsModal` routes to `pinLoginScene` if pin is enabled for the user

--- a/src/components/modals/DateModal.tsx
+++ b/src/components/modals/DateModal.tsx
@@ -85,8 +85,8 @@ export class DateModalIos extends React.Component<Props & ThemeProps, State> {
     )
   }
 
-  handleChange = (event: unknown, date?: Date) => {
-    // @ts-expect-error
+  handleChange = (_event: unknown, date?: Date) => {
+    if (date == null) return
     this.setState({ date })
   }
 
@@ -105,7 +105,7 @@ export function DateModalAndroid(props: Props) {
   return (
     <DateTimePicker
       mode="date"
-      onChange={(event, date?: Date) => {
+      onChange={(_event, date?: Date) => {
         bridge.resolve(date != null ? date : initialValue)
         bridge.remove()
       }}
@@ -116,3 +116,17 @@ export function DateModalAndroid(props: Props) {
 
 export const DateModal =
   Platform.OS === 'android' ? DateModalAndroid : withTheme(DateModalIos)
+
+/**
+ * Returns the date portion of a date object, formatted YYYY-MM-DD.
+ * It makes sure to return the date local to the current timezone.
+ *
+ * It's only use-case is to convert a date object from the date picker modal
+ * to a formatted string.
+ *
+ * @param date A JS Date Object
+ * @returns the formatted date string (YYYY-MM-DD).
+ */
+export function toRecoveryDateString(date: Date): string {
+  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
+}

--- a/src/components/scenes/RecoveryLoginScene.tsx
+++ b/src/components/scenes/RecoveryLoginScene.tsx
@@ -13,7 +13,7 @@ import { SceneProps } from '../../types/routerTypes'
 import { attemptLogin, LoginAttempt } from '../../util/loginAttempt'
 import { Tile } from '../common/Tile'
 import { WarningCard } from '../common/WarningCard'
-import { DateModal } from '../modals/DateModal'
+import { DateModal, toRecoveryDateString } from '../modals/DateModal'
 import { TextInputModal } from '../modals/TextInputModal'
 import { Airship, showError } from '../services/AirshipInstance'
 import { Theme, useTheme } from '../services/ThemeContext'
@@ -51,9 +51,9 @@ export const RecoveryLoginScene = (props: SceneProps<'recoveryLogin'>) => {
     const now = new Date()
     Airship.show<Date>(bridge => (
       <DateModal bridge={bridge} initialValue={now} />
-    )).then(answer => {
-      const date = answer.toISOString().split('T')[0]
-      answers[index] = date
+    )).then(date => {
+      const answer = toRecoveryDateString(date)
+      answers[index] = answer
       setAnswers([...answers])
     })
   }

--- a/src/components/scenes/existingAccout/ChangeRecoveryScene.tsx
+++ b/src/components/scenes/existingAccout/ChangeRecoveryScene.tsx
@@ -21,7 +21,7 @@ import { EdgeTouchableOpacity } from '../../common/EdgeTouchableOpacity'
 import { Tile } from '../../common/Tile'
 import { WarningCard } from '../../common/WarningCard'
 import { ButtonsModal } from '../../modals/ButtonsModal'
-import { DateModal } from '../../modals/DateModal'
+import { DateModal, toRecoveryDateString } from '../../modals/DateModal'
 import { QuestionListModal } from '../../modals/QuestionListModal'
 import { TextInputModal } from '../../modals/TextInputModal'
 import { Airship, showError } from '../../services/AirshipInstance'
@@ -124,9 +124,9 @@ export const ChangeRecoveryScene = (props: Props) => {
     await Airship.show<Date>(bridge => (
       <DateModal bridge={bridge} initialValue={now} />
     ))
-      .then(answer => {
-        const date = answer.toISOString().split('T')[0]
-        answers[index] = date
+      .then(date => {
+        const answer = toRecoveryDateString(date)
+        answers[index] = answer
         setAnswers([...answers])
       })
       .catch((error: Error) => {


### PR DESCRIPTION
The date picker would return the date picked at the current local time
based on the device's locale (timezone). Because `toISOString` was used,
the resulting date my be different then the picked date because the day
in UTC may be a different day then what the current device is in.

To solve this, use `getDate/Month/FullYear` methods which respect locale
to format the ISO formatted date string. This has been abstracted into
a utility.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209096172178430