### PR TITLE
Fix logo clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: `PinLoginScene` and `PasswordLoginScene` logo clipping
+
 ## 3.29.2 (2025-08-12)
 
 - fixed: Button layouts

--- a/src/components/abSpecific/LogoImageHeader.tsx
+++ b/src/components/abSpecific/LogoImageHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Image, View } from 'react-native'
+import { Image, ImageBackground, PixelRatio } from 'react-native'
 import { cacheStyles } from 'react-native-patina'
 
 import * as Assets from '../../assets/'
@@ -19,6 +19,16 @@ export function LogoImageHeader(props: Props): JSX.Element {
   const theme = useTheme()
   const styles = getStyles(theme)
 
+  // Compute a pixel-aligned width while preserving the desired visual height.
+  const imageStyle = React.useMemo(() => {
+    const desiredHeightDp = theme.rem(2.75)
+    const source = Image.resolveAssetSource(primaryLogo)
+    const aspectRatio = source.width / source.height
+    const scale = PixelRatio.get()
+    const widthDp = Math.round(desiredHeightDp * aspectRatio * scale) / scale
+    return { width: widthDp, aspectRatio }
+  }, [primaryLogo, theme])
+
   const taps = React.useRef(0)
   const handlePress = useHandler(() => {
     if (primaryLogoCallback != null) {
@@ -35,27 +45,23 @@ export function LogoImageHeader(props: Props): JSX.Element {
 
   return (
     <EdgeTouchableWithoutFeedback onPress={handlePress}>
-      <View style={styles.container}>
-        <Image
-          accessibilityHint={lstrings.app_logo_hint}
-          source={primaryLogo}
-          style={styles.image}
-          resizeMode="contain"
-        />
-      </View>
+      <ImageBackground
+        accessibilityHint={lstrings.app_logo_hint}
+        source={primaryLogo}
+        resizeMode="contain"
+        style={[styles.imageContainer, imageStyle]}
+      />
     </EdgeTouchableWithoutFeedback>
   )
 }
 
 const getStyles = cacheStyles((theme: Theme) => ({
-  container: {
+  imageContainer: {
     alignItems: 'center',
-    justifyContent: 'space-around',
+    justifyContent: 'center',
     paddingBottom: theme.rem(1.5),
-    width: '100%'
-  },
-  image: {
-    height: theme.rem(2.75),
+    width: '100%',
+    // Height is derived from width + aspectRatio to avoid fractional pixel rounding
     overflow: 'visible',
     resizeMode: 'contain'
   }


### PR DESCRIPTION

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

### Root cause
- On iOS, the logo was rendered via an Image with a fixed height derived from `theme.rem(2.75)`. After a login→logout re-init cycle, layout timing could yield fractional device-pixel dimensions for the Image box. iOS `UIImageView` rasterizes at integral pixel boundaries; when the view’s bounds land on fractional pixels, it can clip a row/column of pixels. That’s why the clipping sometimes appeared on the bottom or the right, and why it typically showed on the second cycle (a slightly different layout pass changed rounding).

### Why it reproduced only after the second cycle
- Logout tears down and recreates the login UI store and reflows the scene. On some reflows, the computed size for the Image landed on a different fractional boundary than the first load, triggering `UIImageView`’s edge clipping. The first cycle often landed on a “good” rounding; the second didn’t.

### Fix
- We stopped sizing the logo by a fixed height and instead:
  - Sized a container by pixel-aligned width plus intrinsic `aspectRatio`.
  - Drew the bitmap using `ImageBackground` inside that container.
- This avoids relying on a height computation that can fall on fractional pixels across different mount cycles, and it uses a composition path (`ImageBackground`) that doesn’t exhibit the same edge clipping.
- Fix works on both platforms even though only ios is affected, so not special-casing this change



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210978905447507