### PR TITLE
Fix `LogoImageHeader` styling on physical devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: `LogoImageHeader` styling on physical devices
+
 ## 3.29.3 (2025-08-15)
 
 - fixed: `PinLoginScene` and `PasswordLoginScene` logo clipping

--- a/src/components/abSpecific/LogoImageHeader.tsx
+++ b/src/components/abSpecific/LogoImageHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Image, ImageBackground, PixelRatio } from 'react-native'
+import { Image, ImageBackground, PixelRatio, ViewStyle } from 'react-native'
 import { cacheStyles } from 'react-native-patina'
 
 import * as Assets from '../../assets/'
@@ -20,13 +20,17 @@ export function LogoImageHeader(props: Props): JSX.Element {
   const styles = getStyles(theme)
 
   // Compute a pixel-aligned width while preserving the desired visual height.
-  const imageStyle = React.useMemo(() => {
+  const imageStyle: ViewStyle = React.useMemo(() => {
     const desiredHeightDp = theme.rem(2.75)
     const source = Image.resolveAssetSource(primaryLogo)
     const aspectRatio = source.width / source.height
     const scale = PixelRatio.get()
     const widthDp = Math.round(desiredHeightDp * aspectRatio * scale) / scale
-    return { width: widthDp, aspectRatio }
+    return {
+      width: widthDp,
+      aspectRatio,
+      alignSelf: 'center'
+    }
   }, [primaryLogo, theme])
 
   const taps = React.useRef(0)
@@ -44,12 +48,15 @@ export function LogoImageHeader(props: Props): JSX.Element {
   })
 
   return (
-    <EdgeTouchableWithoutFeedback onPress={handlePress}>
+    <EdgeTouchableWithoutFeedback
+      onPress={handlePress}
+      style={styles.imageContainer}
+    >
       <ImageBackground
         accessibilityHint={lstrings.app_logo_hint}
         source={primaryLogo}
         resizeMode="contain"
-        style={[styles.imageContainer, imageStyle]}
+        style={imageStyle}
       />
     </EdgeTouchableWithoutFeedback>
   )


### PR DESCRIPTION
For some reason, styles are not applied consistently between simulators and physical devices in this specific scenario...

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
