### PR TITLE
Adjust switch track color in Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: `RequestPermissionsModal` switch color update for Android
+
 ## 3.30.1 (2025-08-25)
 
 - fixed: `LogoImageHeader` styling on physical devices

--- a/src/components/modals/RequestPermissionsModal.tsx
+++ b/src/components/modals/RequestPermissionsModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Switch, View } from 'react-native'
+import { Platform, Switch, View } from 'react-native'
 import { AirshipBridge } from 'react-native-airship'
 import { cacheStyles } from 'react-native-patina'
 
@@ -106,7 +106,14 @@ export function RequestPermissionsModal(props: Props) {
             ios_backgroundColor={theme.deactivatedText}
             trackColor={{
               false: theme.deactivatedText,
-              true: theme.iconTappable
+              true:
+                Platform.OS === 'ios'
+                  ? // iOS applies a dimmed appearance to the track color when
+                    // disabled
+                    theme.iconTappable
+                  : // Android keeps the same track color when disabled - use an
+                    // artificially dimmed version of the color
+                    theme.switchTrackDisabledOn
             }}
             value
           />

--- a/src/constants/themes/edgeDark.ts
+++ b/src/constants/themes/edgeDark.ts
@@ -11,6 +11,7 @@ const palette = {
   edgeNavy: '#0D2145',
   edgeBlue: '#0E4B75',
   edgeMint: '#66EDA8',
+  edgeMintDisabled: '#44bd95',
   darkAqua: '#1b2f3b',
   blueGray: '#A4C7DF',
   gray: '#87939E',
@@ -189,6 +190,9 @@ export const edgeDark: Theme = {
   outlineTextInputBorderColorFocused: palette.edgeMint,
   outlineTextInputLabelColor: palette.blueGray,
   outlineTextInputLabelColorFocused: palette.edgeMint,
+
+  // A switch that's on but not toggleable
+  switchTrackDisabledOn: palette.edgeMintDisabled,
 
   // Simple Text Input
   textInputTextColor: palette.white,

--- a/src/types/Theme.ts
+++ b/src/types/Theme.ts
@@ -340,6 +340,8 @@ export interface Theme {
   pinUsernameButtonFontSizeRem: number
   pinUsernameButtonFont: string
 
+  switchTrackDisabledOn: string
+
   // Outline Text Input
   outlineTextInputColor: string
   outlineTextInputTextColor: string


### PR DESCRIPTION
Android only dims the switch "knob" but not the "track" when a switch is disabled, while iOS dims the entire switch control when a switch is disabled. 

Align Android styling closer to iOS. 

<img width="665" height="450" alt="image" src="https://github.com/user-attachments/assets/8f1096d9-a42b-4431-8470-abd51563f03f" />


### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211147201233369