### PR TITLE
Show readable username network errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Show a readable network error when username availability checks fail.
+
 ## 3.35.4 (2026-03-24)
 
 - changed: Update translations

--- a/src/common/locales/strings/de.json
+++ b/src/common/locales/strings/de.json
@@ -108,7 +108,7 @@
   "must_one_number": "Muss mindestens eine Zahl enthalten",
   "must_one_uppercase": "Muss mindestens einen Großbuchstaben enthalten",
   "must_ten_characters": "Muss mindestens 10 Zeichen lang sein",
-  "network_error_generic": "Unable to connect. Please try again later and check your internet connection.",
+  "network_error_generic": "Unable to connect. Please check your internet connection and try again.",
   "network_error_generic_1s": "Unable to connect. %1$s",
   "next_label": "Weiter",
   "notifications_and_refresh_permissions_branded_s": "Please enable Notifications and Background App Refresh to ensure the highest level of security for your account. %1$s will notify you if other devices attempt to access your account and will allow you to accept or reject access.",

--- a/src/common/locales/strings/enUS.json
+++ b/src/common/locales/strings/enUS.json
@@ -108,7 +108,7 @@
   "must_one_number": "Must have at least 1 number",
   "must_one_uppercase": "Must have at least 1 uppercase letter",
   "must_ten_characters": "Must have at least 10 characters",
-  "network_error_generic": "Unable to connect. Please try again later and check your internet connection.",
+  "network_error_generic": "Unable to connect. Please check your internet connection and try again.",
   "network_error_generic_1s": "Unable to connect. %1$s",
   "next_label": "Next",
   "notifications_and_refresh_permissions_branded_s": "Please enable Notifications and Background App Refresh to ensure the highest level of security for your account. %1$s will notify you if other devices attempt to access your account and will allow you to accept or reject access.",

--- a/src/common/locales/strings/es.json
+++ b/src/common/locales/strings/es.json
@@ -108,7 +108,7 @@
   "must_one_number": "Debe tener al menos un número",
   "must_one_uppercase": "Debe tener al menos una letra mayúscula",
   "must_ten_characters": "Debe tener al menos 10 carácteres",
-  "network_error_generic": "No se pudo conectar. Inténtalo de nuevo más tarde y verifica tu conexión a internet.",
+  "network_error_generic": "No se pudo conectar. Verifica tu conexión a internet y vuelve a intentarlo.",
   "network_error_generic_1s": "No se pudo conectar. %1$s",
   "next_label": "Siguiente",
   "notifications_and_refresh_permissions_branded_s": "Activa las notificaciones y la actualización en segundo plano para garantizar el máximo nivel de seguridad para tu cuenta. %1$s te avisará si otros dispositivos intentan acceder a tu cuenta y te permitirá aceptar o rechazar el acceso.",

--- a/src/common/locales/strings/esMX.json
+++ b/src/common/locales/strings/esMX.json
@@ -108,7 +108,7 @@
   "must_one_number": "Debe tener al menos un número",
   "must_one_uppercase": "Debe tener al menos una letra mayúscula",
   "must_ten_characters": "Debe tener al menos 10 carácteres",
-  "network_error_generic": "No se pudo conectar. Inténtalo de nuevo más tarde y verifica tu conexión a internet.",
+  "network_error_generic": "No se pudo conectar. Verifica tu conexión a internet y vuelve a intentarlo.",
   "network_error_generic_1s": "No se pudo conectar. %1$s",
   "next_label": "Siguiente",
   "notifications_and_refresh_permissions_branded_s": "Habilita las Notificaciones y la Actualización en Segundo Plano para garantizar el máximo nivel de seguridad en tu cuenta. %1$s te notificará si otros dispositivos intentan acceder a tu cuenta y te permitirá aceptar o rechazar el acceso.",

--- a/src/common/locales/strings/fr.json
+++ b/src/common/locales/strings/fr.json
@@ -108,7 +108,7 @@
   "must_one_number": "Doit avoir au moins 1 numéro",
   "must_one_uppercase": "Doit avoir au moins 1 lettre majuscule",
   "must_ten_characters": "Doit avoir au moins 10 caractères",
-  "network_error_generic": "Unable to connect. Please try again later and check your internet connection.",
+  "network_error_generic": "Unable to connect. Please check your internet connection and try again.",
   "network_error_generic_1s": "Unable to connect. %1$s",
   "next_label": "Suivant",
   "notifications_and_refresh_permissions_branded_s": "Please enable Notifications and Background App Refresh to ensure the highest level of security for your account. %1$s will notify you if other devices attempt to access your account and will allow you to accept or reject access.",

--- a/src/common/locales/strings/it.json
+++ b/src/common/locales/strings/it.json
@@ -108,7 +108,7 @@
   "must_one_number": "Deve avere almeno un numero",
   "must_one_uppercase": "Deve avere almeno una lettera maiuscola",
   "must_ten_characters": "Deve avere almeno 10 caratteri",
-  "network_error_generic": "Impossibile connettersi. Riprova più tardi e controlla la tua connessione internet.",
+  "network_error_generic": "Impossibile connettersi. Controlla la tua connessione internet e riprova.",
   "network_error_generic_1s": "Impossibile connettersi. %1$s",
   "next_label": "Avanti",
   "notifications_and_refresh_permissions_branded_s": "Abilita le notifiche e il monitoraggio dell'applicazione in background per assicurare il più alto livello di sicurezza al tuo account. %1$s ti avviserà se altri dispositivi tenteranno di accedere al tuo account e ti permetterà di consentire o rifiutare l'accesso.",

--- a/src/common/locales/strings/ja.json
+++ b/src/common/locales/strings/ja.json
@@ -108,7 +108,7 @@
   "must_one_number": "少なくとも数字が一つ必要です",
   "must_one_uppercase": "少なくとも大文字が一つ必要です",
   "must_ten_characters": "少なくとも１０文字必要です",
-  "network_error_generic": "Unable to connect. Please try again later and check your internet connection.",
+  "network_error_generic": "Unable to connect. Please check your internet connection and try again.",
   "network_error_generic_1s": "Unable to connect. %1$s",
   "next_label": "次へ",
   "notifications_and_refresh_permissions_branded_s": "アカウントの最高レベルのセキュリティを確保するために、通知とバックグラウンドアプリの更新を有効にしてください。%1$sは、他のデバイスがあなたのアカウントにアクセスしようとすると通知し、アクセスを承認または拒否できます。",

--- a/src/common/locales/strings/kaa.json
+++ b/src/common/locales/strings/kaa.json
@@ -108,7 +108,7 @@
   "must_one_number": "Must have at least 1 number",
   "must_one_uppercase": "Must have at least 1 uppercase letter",
   "must_ten_characters": "Must have at least 10 characters",
-  "network_error_generic": "Unable to connect. Please try again later and check your internet connection.",
+  "network_error_generic": "Unable to connect. Please check your internet connection and try again.",
   "network_error_generic_1s": "Unable to connect. %1$s",
   "next_label": "Next",
   "notifications_and_refresh_permissions_branded_s": "Please enable Notifications and Background App Refresh to ensure the highest level of security for your account. %1$s will notify you if other devices attempt to access your account and will allow you to accept or reject access.",

--- a/src/common/locales/strings/ko.json
+++ b/src/common/locales/strings/ko.json
@@ -108,7 +108,7 @@
   "must_one_number": "최소 1자이상의 숫자가 필요합니다.",
   "must_one_uppercase": "최소 1자이상의 대문자가 필요합니다.",
   "must_ten_characters": "최소 10자 이상이어야 합니다.",
-  "network_error_generic": "Unable to connect. Please try again later and check your internet connection.",
+  "network_error_generic": "Unable to connect. Please check your internet connection and try again.",
   "network_error_generic_1s": "Unable to connect. %1$s",
   "next_label": "다음",
   "notifications_and_refresh_permissions_branded_s": "Please enable Notifications and Background App Refresh to ensure the highest level of security for your account. %1$s will notify you if other devices attempt to access your account and will allow you to accept or reject access.",

--- a/src/common/locales/strings/pt.json
+++ b/src/common/locales/strings/pt.json
@@ -108,7 +108,7 @@
   "must_one_number": "Deve ter pelo menos 1 número",
   "must_one_uppercase": "Deve ter pelo menos 1 letra maiúscula",
   "must_ten_characters": "Deve ter pelo menos 10 caracteres",
-  "network_error_generic": "Unable to connect. Please try again later and check your internet connection.",
+  "network_error_generic": "Unable to connect. Please check your internet connection and try again.",
   "network_error_generic_1s": "Unable to connect. %1$s",
   "next_label": "Próximo",
   "notifications_and_refresh_permissions_branded_s": "Por Favor, ative as notificações e a atualização do aplicativo em segundo plano para garantir o mais alto nível de segurança para a sua conta. %1$s Irá notificá-lo se outros dispositivos tentarem acessar a sua conta e permitirá que você aceite ou rejeite o acesso.",

--- a/src/common/locales/strings/ru.json
+++ b/src/common/locales/strings/ru.json
@@ -108,7 +108,7 @@
   "must_one_number": "Должна быть как минимум одна цифра",
   "must_one_uppercase": "Должна быть как минимум одна буква в верхнем регистре",
   "must_ten_characters": "Должно быть не менее 10 символов",
-  "network_error_generic": "Unable to connect. Please try again later and check your internet connection.",
+  "network_error_generic": "Unable to connect. Please check your internet connection and try again.",
   "network_error_generic_1s": "Unable to connect. %1$s",
   "next_label": "Далее",
   "notifications_and_refresh_permissions_branded_s": "Please enable Notifications and Background App Refresh to ensure the highest level of security for your account. %1$s will notify you if other devices attempt to access your account and will allow you to accept or reject access.",

--- a/src/common/locales/strings/vi.json
+++ b/src/common/locales/strings/vi.json
@@ -108,7 +108,7 @@
   "must_one_number": "Bắt buộc phải có ít nhất 1 chữ số",
   "must_one_uppercase": "Bắt buộc phải có ít nhất 1 chữ cái in hoa",
   "must_ten_characters": "Phải có ít nhất 10 kí tự",
-  "network_error_generic": "Unable to connect. Please try again later and check your internet connection.",
+  "network_error_generic": "Unable to connect. Please check your internet connection and try again.",
   "network_error_generic_1s": "Unable to connect. %1$s",
   "next_label": "Đi tiếp",
   "notifications_and_refresh_permissions_branded_s": "Please enable Notifications and Background App Refresh to ensure the highest level of security for your account. %1$s will notify you if other devices attempt to access your account and will allow you to accept or reject access.",

--- a/src/common/locales/strings/zh.json
+++ b/src/common/locales/strings/zh.json
@@ -108,7 +108,7 @@
   "must_one_number": "必须至少有一个数字",
   "must_one_uppercase": "必须至少有一个大写字母",
   "must_ten_characters": "必须有至少 10 个字符",
-  "network_error_generic": "Unable to connect. Please try again later and check your internet connection.",
+  "network_error_generic": "Unable to connect. Please check your internet connection and try again.",
   "network_error_generic_1s": "Unable to connect. %1$s",
   "next_label": "下一步",
   "notifications_and_refresh_permissions_branded_s": "Please enable Notifications and Background App Refresh to ensure the highest level of security for your account. %1$s will notify you if other devices attempt to access your account and will allow you to accept or reject access.",

--- a/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
@@ -1,4 +1,4 @@
-import { EdgeAccount } from 'edge-core-js'
+import { asMaybeNetworkError, EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { cacheStyles } from 'react-native-patina'
@@ -191,7 +191,13 @@ export const ChangeUsernameComponent = (props: Props) => {
           }
           onCheckDone(undefined, lstrings.username_exists_error)
         },
-        error => onCheckDone(undefined, String(error))
+        (error: unknown) => {
+          if (asMaybeNetworkError(error) != null) {
+            onCheckDone(undefined, lstrings.network_error_generic)
+            return
+          }
+          onCheckDone(undefined, String(error))
+        }
       )
     }, AVAILABILITY_CHECK_DELAY_MS)
     setTimerId(newTimerId)


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1211104934056420/f)

Follow-up to Asana task `1211104934056420` and the earlier linked task for human-readable login errors.

Updates the account creation `Choose Username` flow to map username availability network failures to the existing generic network error message instead of showing raw auth server details such as `/v2/login`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small UI error-handling change that maps username availability network failures to an existing generic message, plus minor copy updates to the `network_error_generic` string across locales.
> 
> **Overview**
> **Improves account creation username UX by hiding raw server/network details.** `NewAccountUsernameScene` now detects network-related failures during username availability checks (via `asMaybeNetworkError`) and displays `lstrings.network_error_generic` instead of stringifying the underlying error.
> 
> Updates the `network_error_generic` wording across multiple locale JSON files and adds a matching *Unreleased* changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 766706fb85ff2bd3046a34d1d3cb0390f2749216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->