### PR TITLE
Match login password length cap to account creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Match login password length cap to account creation to prevent silent truncation mismatches.
+
 ## 3.35.6 (2026-04-24)
 
 - changed: Update translations

--- a/src/components/scenes/PasswordLoginScene.tsx
+++ b/src/components/scenes/PasswordLoginScene.tsx
@@ -518,6 +518,7 @@ export const PasswordLoginScene = (props: Props) => {
           autoCorrect={false}
           autoFocus={false}
           error={passwordErrorMessage}
+          maxLength={100}
           placeholder={lstrings.password}
           returnKeyType="done"
           secureTextEntry

--- a/src/components/scenes/PasswordLoginScene.tsx
+++ b/src/components/scenes/PasswordLoginScene.tsx
@@ -351,7 +351,13 @@ export const PasswordLoginScene = (props: Props) => {
 
       if (base58.parseUnsafe(recoveryKey)?.length !== 32)
         return lstrings.recovery_token_invalid
-      dispatch(launchPasswordRecovery(recoveryKey))
+      dispatch(launchPasswordRecovery(recoveryKey)).catch((err: unknown) => {
+        if (asMaybeNetworkError(err) != null) {
+          showError(lstrings.network_error_generic)
+          return
+        }
+        showError(err)
+      })
       return true
     }
   )


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1210827445652854/f)

Asana: [Account/Login - Password Limit Mismatch](https://app.asana.com/1/9976422036640/project/1213880789473005/task/1210827445652854?focus=true)

**Bug:** During account creation, `ChangePasswordScene` has `maxLength={100}` on its password inputs (lines 155 and 170), silently truncating any longer input. The login input in `PasswordLoginScene` had no cap, and `edge-core-js` hashes whatever it is given (`makeHashInput(username, password)` → scrypt, no length check).

A user set a 250-char password at signup — only the first 100 chars made it into the stored hash. On login, the input accepted the full 250 chars, scrypt hashed a different string, and auth failed. It was resolved manually by truncating the stored copy to 100 chars.

**Fix:** Add `maxLength={100}` to the login password `FilledTextInput` so both flows cap identically. Since creation has always been capped at 100, no existing account has a >100-char password — applying the same cap to login excludes nobody real and guarantees signup and login hash the same input.

`ChangePasswordScene` is re-exported as both `NewAccountPasswordScene` and `UpgradePasswordScene`, so the creation side (already capped at 100) needs no change.

Also included: a small pre-existing lint fix (floating promise in `handleSubmitRecoveryKey`) in its own commit so the `.tsx` file is lint-clean after the feature change.

**Manual test:**
- On the password login screen, paste a 200-char string — the field stops accepting at 100 chars.
- Create a new account with a 150-char pasted password; input caps at 100. Log out, log in with the same 150-char paste; input caps at 100 identically; login succeeds.
- Short passwords (10-char min) still work; <10 still shows the existing min-length requirement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/input constraint change plus a small error-handling tweak; main impact is truncating pasted/typed login passwords over 100 characters to match signup behavior.
> 
> **Overview**
> Prevents login failures caused by *silent truncation during signup* by capping the password field in `PasswordLoginScene` to `maxLength={100}`, matching the account-creation flow.
> 
> Also fixes a floating promise in recovery-key submission by catching `launchPasswordRecovery` errors and showing a generic message for network failures. Updates the `CHANGELOG` with the unreleased fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7a45ee778b41b9411b0b7417412adcc3138660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->