### PR TITLE
Prevent reactive text shrinking on TOS checkbox labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Prevent reactive text shrinking on TOS checkbox labels
+
 ## 3.35.7 (2026-04-28)
 
 - fixed: Match login password length cap to account creation to prevent silent truncation mismatches.

--- a/src/components/scenes/PasswordLoginScene.tsx
+++ b/src/components/scenes/PasswordLoginScene.tsx
@@ -490,10 +490,9 @@ export const PasswordLoginScene = (props: Props) => {
           onScroll={scrollHandler}
         >
           {localUsers.map(userInfo => {
-            const { username } = userInfo
             return (
               <UserListItem
-                key={username}
+                key={userInfo.loginId}
                 userInfo={userInfo}
                 onClick={handleSelectUser}
                 onDelete={handleDelete}

--- a/src/components/scenes/newAccount/NewAccountTosScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountTosScene.tsx
@@ -86,6 +86,8 @@ const TosComponent = (props: Props) => {
             <Checkbox
               textStyle={styles.term}
               value={termValues[index]}
+              numberOfLines={0}
+              disableFontScaling
               onChange={(value: boolean) => handleStatusChange(index, value)}
               marginRem={[0, 0, 1.33, 0]}
             >

--- a/src/components/themed/Checkbox.tsx
+++ b/src/components/themed/Checkbox.tsx
@@ -17,6 +17,7 @@ interface Props {
   disabled?: boolean
   marginRem?: number[] | number
   onChange: (value: boolean) => void
+  disableFontScaling?: boolean
 }
 
 const CheckboxComponent = ({
@@ -28,6 +29,7 @@ const CheckboxComponent = ({
   marginRem,
   ellipsizeMode,
   numberOfLines,
+  disableFontScaling = false,
   theme
 }: Props & ThemeProps) => {
   const styles = getStyles(theme)
@@ -53,6 +55,7 @@ const CheckboxComponent = ({
           style={[styles.label, textStyle]}
           ellipsizeMode={ellipsizeMode}
           numberOfLines={numberOfLines}
+          disableFontScaling={disableFontScaling}
         >
           {children}
         </EdgeText>

--- a/src/components/themed/FilledTextInput.tsx
+++ b/src/components/themed/FilledTextInput.tsx
@@ -608,13 +608,12 @@ const PlaceholderText = styled(Animated.Text)<{
     shift,
     textsizeRem
   }) => {
-    const fontSizeBase = theme.rem(textsizeRem ?? scale.value)
-    const fontSizeScaled = theme.rem(scale.value) * 0.75
     const interpolatePlaceholderTextColor = useAnimatedColorInterpolateFn(
       theme.textInputPlaceholderColor,
       theme.textInputPlaceholderColorFocused,
       theme.textInputPlaceholderColorDisabled
     )
+    const oneRem = theme.rem(1)
 
     return [
       {
@@ -623,6 +622,8 @@ const PlaceholderText = styled(Animated.Text)<{
         includeFontPadding: false
       },
       useAnimatedStyle(() => {
+        const fontSizeBase = oneRem * (textsizeRem ?? scale.value)
+        const fontSizeScaled = oneRem * scale.value * 0.75
         return {
           color: interpolatePlaceholderTextColor(
             focusAnimation,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI tweaks: adjusts text scaling/wrapping for TOS checkbox labels and a minor React list key change; no auth or data-flow changes.
> 
> **Overview**
> Prevents Terms of Service checkbox labels from *reactively shrinking* by allowing unlimited wrapping (`numberOfLines={0}`) and exposing `disableFontScaling` through `Checkbox` to pass down to `EdgeText`.
> 
> Also tightens UI correctness by switching `PasswordLoginScene` dropdown list item keys to use `loginId` (instead of `username`) and refactors `FilledTextInput` placeholder font-size animation to compute sizes from a cached `oneRem` value. Updates `CHANGELOG.md` with the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48b486068791e21437fc3e780e326c4bc854484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214279625193720