### PR TITLE
Warn about other logged-in devices when changing username

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# Edge Login UI - Agent Guidelines
+
+## Package Manager
+
+- **Use npm** for all package management and script execution (the repo was recently converted from Yarn to npm)
+- `npm ci` - Install dependencies from the lockfile (CI-style, reproducible)
+- `npm install <package>` - Add new dependency
+- `npm install -D <package>` - Add dev dependency
+
+## Build/Test/Lint Commands
+
+- `npm run lint` - Run ESLint on the repo
+- `npm run fix` - Auto-fix linting issues (`eslint . --fix`)
+- `npm run flow` - Flow type checking
+- `tsc` - TypeScript type checking
+- `npm run precommit` - Full pre-commit check (lint-staged, flow, tsc)
+- `npm run prepare` - Build the published `lib/` output (rimraf, tsc, copy Flow entry + assets)
+- This repo has no Jest suite; verification is `tsc` + `flow` + ESLint
+
+## Code Style Guidelines
+
+- **Formatting**: Prettier (via `standard-kit`) with single quotes, no semicolons, no trailing commas, 80 char width
+- **Imports**: Use `simple-import-sort` plugin for automatic import sorting
+- **Types**: TypeScript required, prefer explicit types over `any`. A legacy Flow entry point (`src/index.flow.js`) is shipped for Flow consumers, so keep the public type surface in sync
+- **React**: Use functional components with hooks, prefer `useHandler` over `useCallback`
+- **Naming**: camelCase for variables/functions, PascalCase for components/types
+- **Files**: `.tsx` for React components, `.ts` for utilities/hooks
+- **Error Handling**: Use proper error boundaries, avoid throwing in render
+- **Text Components**: Use `EdgeText`, `Paragraph`, `SmallText`, `WarningText` (or `UnscaledText` for text that must not scale with the font-size setting) instead of raw text
+- **Component Reuse**: Strongly prefer reusing existing shared components over building new ones or dropping to raw library primitives. Before adding UI, look for a component that already covers the need (e.g. text via `EdgeText`), and keep color, sizing, and styling driven by `useTheme()` rather than hard-coded per call site. For warning/error surfaces use the UI4 `AlertCard` (`src/components/ui4/AlertCard.tsx`), not the older bordered `common/WarningCard`. When nothing suitable exists, add a reusable, themed definition instead of a one-off
+- **Spacing**: Keep a minimum of 1rem TOTAL space between an element and its neighbors, including screen edges. "Total" is the sum contributed across nearby and parent elements, so examine them rather than each element in isolation: scene-edge padding from `ThemedScene` (`paddingRem`, default 0.5rem) plus an element's own 0.5rem margins via `Space`/`useSpaceStyle` compose to the 1rem total. An explicit override always takes precedence: the "unless otherwise specified" escape hatch applies to every case, screen edges included. The only built-in exception is flex layouts, which rely on flex gap and alignment for sibling spacing; even there, the 1rem screen-edge minimum still applies. Express spacing in rem through the layout primitives instead of hard-coded pixel margins
+- **Hooks**: Custom hooks in `src/hooks/`, follow `use*` naming convention
+- **Testing**: No Jest suite in this repo; rely on `tsc` and `flow` type-checking plus ESLint
+
+## Sync With edge-react-gui
+
+Several components are shared verbatim with `edge-react-gui` and carry an `IMPORTANT: Changes in this file MUST be synced...` header (e.g. `SceneButtons`, `TextInputModal`). Changes to those files must be mirrored in both repos. The conventions above (spacing, formatting, component reuse) match `edge-react-gui`'s `AGENTS.md`.
+
+## Git Conventions
+
+### Commit Messages
+
+- **Subject**: Imperative mood, capitalize first letter, max 50 chars, no period
+- **Body**: Explain what/why (not how), wrap at 72 chars, separate from subject with blank line
+- **Clean commits**: Each commit should be standalone, build successfully, and improve code
+- **Rebasing**: Use interactive rebase to split, squash, and reorder commits before PR
+
+### Pull Requests
+
+- **Future commits**: Use "future! branch-name" for feature dependencies not yet merged
+- **Draft PRs**: Mark PRs with future commits as draft until dependencies are merged
+- **Fixup commits**: Use `git commit --fixup <hash>` for PR feedback, then squash with `git rebase -i --autosquash`
+
+### Branch Dependencies
+
+- Create pseudo-merge commits with "future! branch-name" for dependent features
+- Use `git rebase --onto` to update dependent branches when base changes
+- Remove future commits by rebasing onto master once dependencies are merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: Warn users on the change-username scene that other logged-in devices will keep the old username and must log out and sign back in with the new one.
+
 ## 3.36.0 (2026-06-13)
 
 - changed: Convert the build tooling from Yarn to npm.

--- a/src/common/locales/strings/enUS.json
+++ b/src/common/locales/strings/enUS.json
@@ -44,6 +44,7 @@
   "change_recovery_question6": "What is the birthdate of your favorite niece or nephew?",
   "change_recovery_question8": "What was your address in college?",
   "change_recovery_question9": "What was your maternal grandfather's first and last name?",
+  "change_username_warning": "Changing your username only updates it on this device. Any other devices logged into this account will keep the old username. To keep using them, log out of those devices and sign back in with your new username.",
   "choose_recovery_question": "Choose recovery question",
   "choose_title_password": "Set Password",
   "choose_title_pin": "Set PIN",

--- a/src/components/scenes/existingAccout/ChangeUsernameScene.tsx
+++ b/src/components/scenes/existingAccout/ChangeUsernameScene.tsx
@@ -1,6 +1,7 @@
 import { EdgeAccount } from 'edge-core-js'
 import * as React from 'react'
 
+import { lstrings } from '../../../common/locales/strings'
 import { useHandler } from '../../../hooks/useHandler'
 import { useImports } from '../../../hooks/useImports'
 import { Branding } from '../../../types/Branding'
@@ -34,6 +35,7 @@ export const ChangeUsernameScene = (props: ChangeUsernameProps) => {
     <ChangeUsernameComponent
       initUsername={account.username ?? ''}
       branding={branding}
+      warningMessage={lstrings.change_username_warning}
       onNext={handleNext}
     />
   )

--- a/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
@@ -20,6 +20,7 @@ import { Theme, useTheme } from '../../services/ThemeContext'
 import { EdgeText } from '../../themed/EdgeText'
 import { FilledTextInput } from '../../themed/FilledTextInput'
 import { ThemedScene } from '../../themed/ThemedScene'
+import { AlertCard } from '../../ui4/AlertCard'
 
 export interface NewAccountUsernameParams {
   password?: string
@@ -41,12 +42,20 @@ interface Props {
   branding: Branding
   initUsername?: string
   title?: string
+  warningMessage?: string
   onBack?: () => void
   onNext: (username: string) => void | Promise<void>
 }
 
 export const ChangeUsernameComponent = (props: Props) => {
-  const { branding, initUsername, title, onBack, onNext } = props
+  const {
+    branding,
+    initUsername,
+    title,
+    warningMessage,
+    onBack,
+    onNext
+  } = props
   const { context } = useImports()
   const theme = useTheme()
   const styles = getStyles(theme)
@@ -217,6 +226,16 @@ export const ChangeUsernameComponent = (props: Props) => {
             )}
           </EdgeText>
         </EdgeAnim>
+        {warningMessage == null ? null : (
+          <EdgeAnim enter={{ type: 'fadeInUp', distance: 50 }}>
+            <AlertCard
+              type="warning"
+              title={lstrings.warning}
+              body={warningMessage}
+              marginRem={[0, 0.5, 1, 0.5]}
+            />
+          </EdgeAnim>
+        )}
         <EdgeAnim enter={{ type: 'fadeInDown', distance: 25 }}>
           <FilledTextInput
             horizontal={0.5}

--- a/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
+++ b/src/components/scenes/newAccount/NewAccountUsernameScene.tsx
@@ -219,7 +219,8 @@ export const ChangeUsernameComponent = (props: Props) => {
         </EdgeAnim>
         <EdgeAnim enter={{ type: 'fadeInDown', distance: 25 }}>
           <FilledTextInput
-            around={1}
+            horizontal={0.5}
+            vertical={1}
             autoCapitalize="none"
             autoCorrect={false}
             autoFocus
@@ -267,11 +268,11 @@ const getStyles = cacheStyles((theme: Theme) => ({
   },
   mainScrollView: {
     flexGrow: 1,
-    alignContent: 'flex-start',
-    marginHorizontal: theme.rem(0.5)
+    alignContent: 'flex-start'
   },
   description: {
     fontSize: theme.rem(0.875),
+    marginHorizontal: theme.rem(0.5),
     marginBottom: theme.rem(1)
   }
 }))


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Changing a username on one device does not propagate to other devices already logged into the same account. Those devices keep the OLD username, so the user can no longer unlock account settings or re-login there with the correct password because the username no longer matches.

This adds a UI4 warning card to the change-username scene advising the user that changing their username only updates it on the current device, and that other logged-in devices must log out and sign back in with the new username. The warning is scoped to the existing-account change flow (`ChangeUsernameScene`) via a new optional `warningMessage` prop on the shared `ChangeUsernameComponent`; new-account creation (`NewAccountUsernameScene`) and light-account upgrade (`UpgradeUsernameScene`), which reuse the component, do not show it.

While adding the card, the scene's components each sat at a different horizontal inset from the screen edge (the scroll view added its own 0.5rem margin on top of the scene padding, and elements added their own margins unevenly). This PR also:

- Adds `AGENTS.md` codifying the "1rem" spacing convention (a minimum of 1rem total space between an element and its neighbors, including screen edges), lifted from `edge-react-gui`'s `AGENTS.md` and adapted to this repo's primitives (`ThemedScene` `paddingRem`, `Space`/`useSpaceStyle`).
- Applies that convention to the username scene so the description, warning card, username input, and buttons all align at 1rem from the screen edge.

Asana: https://app.asana.com/0/1215088146871429/1211390381991150

### Screenshot

<img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-login-ui-rn/pr-296/20260724-134328-agent-proof-1216833234330851-14-username-warning-1rem-aligned.png" width="360" alt="change username warning card, 1rem-aligned" />

The description text, warning-card border, and username-input border now share the same 1rem left inset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Informational UI and copy only; username change behavior is unchanged and no security-sensitive logic is modified.
> 
> **Overview**
> Adds a **warning** on the existing-account **change username** flow: a UI4 `AlertCard` explains that the new username applies only on the current device and that other logged-in devices must log out and sign in again with the new username. The shared `ChangeUsernameComponent` gains an optional `warningMessage` prop; only `ChangeUsernameScene` passes the new `change_username_warning` string—new-account and light-account upgrade flows are unchanged.
> 
> The username scene layout is adjusted so description, warning card, and input align at the **1rem** screen-edge convention (scroll view margin removed; per-element `horizontal`/`marginRem` spacing). **`AGENTS.md`** documents repo conventions (npm, lint/flow/tsc, spacing, `AlertCard`, sync with edge-react-gui). **CHANGELOG** records the user-facing warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f26bf5763d768098d4f3b9731eababb0be4b2d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->