### PR TITLE
Harden new-account creation against lost create responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- fixed: Recover a half-created account by logging in with the entered credentials when account creation fails with a NetworkError, instead of dead-ending at "account already exists".
+- fixed: Clear the consumed single-use create challenge id once a create attempt settles, so a retry fetches a fresh challenge instead of replaying a dead id and popping a redundant CAPTCHA modal.
+
 ## 3.37.0 (2026-07-27)
 
 - added: Warn users on the change-username scene that other logged-in devices will keep the old username and must log out and sign back in with the new one.

--- a/src/hooks/useCreateAccount.ts
+++ b/src/hooks/useCreateAccount.ts
@@ -1,3 +1,5 @@
+import { asMaybeNetworkError, EdgeAccount } from 'edge-core-js'
+
 import { loadTouchState } from '../actions/TouchActions'
 import { retryOnChallenge } from '../components/modals/ChallengeModal'
 import { enableTouchId } from '../keychain'
@@ -19,27 +21,61 @@ export const useCreateAccountHandler = () => {
     }) => {
       const { username, password, pin } = createAccountParams
 
-      return await retryOnChallenge({
-        cancelValue: undefined,
-        async task(challengeId = savedChallengeId) {
-          const account = await context.createAccount({
-            ...accountOptions,
-            challengeId,
-            username,
-            password,
-            pin
-          })
-          account.watch('loggedIn', loggedIn => {
-            if (!loggedIn) dispatch({ type: 'RESET_APP' })
-          })
-          await enableTouchId(account).catch(e => {
-            console.log(e) // Fail quietly
-          })
-          dispatch(loadTouchState())
+      // Wire up a freshly-obtained account the same way whether it came from
+      // createAccount or from a recovery login, then hand it back to the caller.
+      const finishAccount = async (
+        account: EdgeAccount
+      ): Promise<EdgeAccount> => {
+        account.watch('loggedIn', loggedIn => {
+          if (!loggedIn) dispatch({ type: 'RESET_APP' })
+        })
+        await enableTouchId(account).catch((e: unknown) => {
+          console.log(e) // Fail quietly
+        })
+        dispatch(loadTouchState()).catch((e: unknown) => {
+          console.log(e) // Fail quietly
+        })
 
-          return account
+        return account
+      }
+
+      try {
+        return await retryOnChallenge({
+          cancelValue: undefined,
+          async task(challengeId = savedChallengeId) {
+            const account = await context.createAccount({
+              ...accountOptions,
+              challengeId,
+              username,
+              password,
+              pin
+            })
+            return await finishAccount(account)
+          }
+        })
+      } catch (error: unknown) {
+        // A lost create response can leave the account created server-side while
+        // the client sees a NetworkError. The orphaned account has exactly the
+        // credentials just entered, so a password login recovers it and lets
+        // signup continue instead of dead-ending at "account already exists".
+        if (
+          asMaybeNetworkError(error) != null &&
+          username != null &&
+          password != null
+        ) {
+          const recovered = await context
+            .loginWithPassword(username, password, accountOptions)
+            .catch(() => undefined)
+          if (recovered != null) return await finishAccount(recovered)
         }
-      })
+        throw error
+      } finally {
+        // Create challenges are single-use and consumed the moment the request
+        // reaches the server. Drop the saved id once the attempt settles so a
+        // retry fetches a fresh challenge instead of replaying a dead id (which
+        // returns 429 and pops a redundant CAPTCHA modal).
+        dispatch({ type: 'CLEAR_CREATE_CHALLENGE' })
+      }
     }
   )
 

--- a/src/reducers/RootReducer.ts
+++ b/src/reducers/RootReducer.ts
@@ -15,7 +15,14 @@ export const rootReducer = combineReducers<RootState>({
     state: string | null = null,
     action: Action
   ): string | null {
-    return action.type === 'CREATE_CHALLENGE' ? action.data : state
+    switch (action.type) {
+      case 'CREATE_CHALLENGE':
+        return action.data
+      case 'CLEAR_CREATE_CHALLENGE':
+        return null
+      default:
+        return state
+    }
   },
   scene,
   touch

--- a/src/types/ReduxActions.ts
+++ b/src/types/ReduxActions.ts
@@ -4,6 +4,7 @@ import { TouchState } from '../reducers/TouchReducer'
 export type Action =
   // Actions with no payload:
   | { type: 'RESET_APP' }
+  | { type: 'CLEAR_CREATE_CHALLENGE' }
   // Actions with known payloads:
   | { type: 'CREATE_CHALLENGE'; data: string }
   | { type: 'NAVIGATE'; data: SceneState }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Asana: https://app.asana.com/0/1215088146871429/1217058350202033

Client hardening for the dead-sync-server incident, where a lost `/v2/login/create` response left the account created server-side while the user saw a NetworkError and every retry dead-ended at "account already exists" after burning a CAPTCHA.

**2a. Recover a half-created account on NetworkError** (`useCreateAccount.ts`)
When `createAccount` throws a `NetworkError` and the user supplied a username + password, quietly probe `context.loginWithPassword(username, password, accountOptions)` before surfacing the error. The orphaned account has exactly the credentials just entered, so a successful login continues signup with that account instead of bouncing to TOS. Probe failure falls through to the existing error UX. The post-account wiring (touch, `loggedIn` watch) is factored into a `finishAccount` helper shared by the create and recovery paths.

**2b. Clear the consumed challenge id** (`useCreateAccount.ts`, `ReduxActions.ts`, `RootReducer.ts`)
Server-side create challenges are single-use, consumed the moment a `createAccount` request reaches the server. The client kept `state.createChallengeId` forever, so every retry replayed a dead id, got 429 CAPTCHA-required, and popped a redundant ALTCHA modal. A new `CLEAR_CREATE_CHALLENGE` action resets `createChallengeId`, dispatched in a `finally` once a create attempt settles so a retry fetches a fresh challenge.

No behavior change on happy paths.

### Testing

Exercised in `edge-react-gui` (iOS sim) with this branch linked via `updot`:

- **Happy path (real-action drive to terminal success):** created a brand-new account through the full Choose Username → Set Password → Set PIN → Terms → Confirm flow and landed on the app Home screen. Confirms no regression and that the `CLEAR_CREATE_CHALLENGE` dispatch runs in the `finally` without breaking creation.
- **2a recovery (hack-verified):** temporarily forced `createAccount` to throw a `NetworkError` immediately after it created the account (simulating the lost create response), then drove the create flow with a fresh username. The `loginWithPassword` recovery caught the account and advanced to the Review scene — the exact scene an un-recovered NetworkError would never reach (it would bounce back to TOS). Hack reverted, tree clean.

Static: `tsc`, `flow` (0 errors), and eslint all pass.
